### PR TITLE
Fix segfaults in Python module on unknown error codes

### DIFF
--- a/miniupnpc/upnperrors.c
+++ b/miniupnpc/upnperrors.c
@@ -97,7 +97,8 @@ const char * strupnperror(int err)
 		s = "ExternalPortOnlySupportsWildcard";
 		break;
 	default:
-		s = NULL;
+		s = "UnknownError";
+		break;
 	}
 	return s;
 }


### PR DESCRIPTION
Previously, the strupnperror function in upnperrors.c would return (const char *)NULL for unknown error codes. When this happened, the Python module would segfault as it tried to generate an error code from a string at a NULL pointer.

This change returns "UnknownError" as the default error string, which prevents segmentation faults.
