### PR TITLE
A few command line updates for miniupnpd

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -820,6 +820,32 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPMINISSDPDSOCKET:
 				minissdpdsocketpath = ary_options[i].value;
 				break;
+#ifdef ENABLE_PERMISSION_RULES
+			case UPNPPERMISSIONRULE:
+			{
+				void *tmp = realloc(upnppermlist, sizeof(struct upnpperm) * (num_upnpperm+1));
+				if(tmp == NULL)
+				{
+					fprintf(stderr, "memory allocation error. Permission line in file %s\n",
+							optionsfile);
+				}
+				else
+				{
+					upnppermlist = tmp;
+					/* parse the rule */
+					if(read_permission_line(upnppermlist + num_upnpperm, (char *)ary_options[i].value) >= 0)
+					{
+						num_upnpperm++;
+					}
+					else
+					{
+						fprintf(stderr, "parsing error file %s : %s\n", 
+								optionsfile, ary_options[i].value);
+					}
+				}
+			}
+			break;
+#endif /* ENABLE_PERMISSION_RULES */
 			default:
 				fprintf(stderr, "Unknown option in file %s\n",
 				        optionsfile);
@@ -1047,6 +1073,45 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				fprintf(stderr, "Option -%c takes two arguments.\n", argv[i][1]);
 #endif			
 			break;
+#ifdef ENABLE_PERMISSION_RULES
+		case 'A':
+			if(i+4 < argc)
+			{
+				void *tmp = realloc(upnppermlist, sizeof(struct upnpperm) * (num_upnpperm+1));
+				if(tmp == NULL)
+				{
+					fprintf(stderr, "memory allocation error for permission ruleset\n");
+				}
+				else
+				{
+					char *val=calloc((strlen(argv[i+1]) + strlen(argv[i+2]) + strlen(argv[i+3]) + strlen(argv[i+4]) + 4), sizeof(char));
+					if(val == NULL)
+					{
+						fprintf(stderr, "memory allocation error for ruleset storage\n");
+					}
+
+					sprintf(val, "%s %s %s %s", argv[i+1], argv[i+2], argv[i+3], argv[i+4]);
+
+					upnppermlist = tmp;
+					/* parse the rule */
+					if(read_permission_line(upnppermlist + num_upnpperm, val) >= 0)
+					{
+						num_upnpperm++;
+					}
+					else
+					{
+						fprintf(stderr, "parsing error file %s : %s\n", 
+								optionsfile, ary_options[i].value);
+					}
+
+					free(val);
+					i+=4;
+				}
+			}
+			else
+				fprintf(stderr, "Option -%c takes four arguments.\n", argv[i][1]);
+			break;
+#endif /* ENABLE_PERMISSION_RULES */
 			break;
 		case 'f':
 			i++;	/* discarding, the config file is already read */

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -58,6 +58,9 @@ static const struct {
 #ifdef ENABLE_LEASEFILE
 	{ UPNPLEASEFILE, "lease_file"},
 #endif
+#ifdef ENABLE_PERMISSION_RULES
+	{ UPNPPERMISSIONRULE, "permission_rule"},
+#endif
 	{ UPNPMINISSDPDSOCKET, "minissdpdsocket"},
 	{ UPNPSECUREMODE, "secure_mode"}
 };

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -47,6 +47,9 @@ enum upnpconfigoptions {
 #ifdef ENABLE_LEASEFILE
 	UPNPLEASEFILE,			/* lease_file */
 #endif
+#ifdef ENABLE_PERMISSION_RULES	
+	UPNPPERMISSIONRULE,		/* permission rules */
+#endif
 	UPNPMINISSDPDSOCKET,	/* minissdpdsocket */
 	UPNPENABLE				/* enable_upnp */
 };


### PR DESCRIPTION
Here are a few updates I made to miniupnpd, some of which I think can be useful, others maybe a bit superfluous.  The major two things that I think may be useful are the ENABLE_PERMISSIONS_RULE and the command line fix for listening addresses.  I believe these are nice fixes for command line processing.  (I hope I am doing this right, this is my first pull request)
