### PR TITLE
miniupnpc: Support Python 3

### DIFF
--- a/miniupnpc/Makefile
+++ b/miniupnpc/Makefile
@@ -131,6 +131,13 @@ pythonmodule:	$(LIBRARY) miniupnpcmodule.c setup.py
 installpythonmodule:	pythonmodule
 	python setup.py install
 
+pythonmodule3:	$(LIBRARY) miniupnpcmodule.c setup.py
+	python3 setup.py build
+	touch $@
+
+installpythonmodule3:	pythonmodule3
+	python3 setup.py install
+
 validateminixml:	minixmlvalid
 	@echo "minixml validation test"
 	./minixmlvalid
@@ -144,7 +151,7 @@ validateminiwget:	testminiwget minihttptestserver testminiwget.sh
 clean:
 	$(RM) $(LIBRARY) $(SHAREDLIBRARY) $(EXECUTABLES) $(OBJS) miniupnpcstrings.h
 	# clean python stuff
-	$(RM) pythonmodule validateminixml validateminiwget
+	$(RM) pythonmodule pythonmodule3 validateminixml validateminiwget
 	$(RM) -r build/ dist/
 	#python setup.py clean
 	# clean jnaerator stuff


### PR DESCRIPTION
This pull request contains changes to the Python bindings, for miniupnpc, to support Python 3. Maintains backwards compatibility. New makefile targets: pythonmodule3, installpythonmodule3. 
