### PR TITLE
IPFW update

### DIFF
--- a/miniupnpd/.gitignore
+++ b/miniupnpd/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.bak
 config.h
+ipfw/testipfwrdr
 miniupnpd
 miniupnpdctl
 testgetifaddr

--- a/miniupnpd/Makefile.macosx
+++ b/miniupnpd/Makefile.macosx
@@ -26,7 +26,7 @@ STD_OBJS = miniupnpd.o upnphttp.o upnpdescgen.o upnpsoap.o \
           options.o upnppermissions.o minissdp.o natpmp.o \
 	  upnpevents.o getconnstatus.o upnputils.o
 MAC_OBJS = mac/getifstats.o bsd/ifacewatcher.o
-IPFW_OBJS = ipfw/ipfwrdr.o
+IPFW_OBJS = ipfw/ipfwrdr.o ipfw/ipfwaux.o
 MISC_OBJS = upnpreplyparse.o minixml.o
 
 ALL_OBJS = $(STD_OBJS) $(MISC_OBJS) $(MAC_OBJS) $(IPFW_OBJS)

--- a/miniupnpd/ipfw/Makefile
+++ b/miniupnpd/ipfw/Makefile
@@ -3,15 +3,15 @@ CC=gcc
 CFLAGS=-Wall -g -I.
 RM=rm -f
 
-all:	testipfwrdr
+all: testipfwrdr
 
 clean:
 	$(RM) *.o testipfwrdr
 
-testipfwrdr:	testipfwrdr.o ipfwrdr.o
+testipfwrdr: testipfwrdr.o ipfwrdr.o ipfwaux.o
 	$(CC) -o $@ $^
 
-ipfwrdr.o:	ipfwrdr.c
+ipfwrdr.o: ipfwrdr.c ipfwaux.c
 
-testipfwrdr.o:	testipfwrdr.c
+testipfwrdr.o: testipfwrdr.c
 

--- a/miniupnpd/ipfw/ipfwaux.c
+++ b/miniupnpd/ipfw/ipfwaux.c
@@ -1,0 +1,107 @@
+/*
+ * MiniUPnP project
+ * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
+ * (c) 2009-2012 Jardel Weyrich
+ * This software is subject to the conditions detailed
+ * in the LICENCE file provided within the distribution
+ */
+
+#include "ipfwaux.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+int ipfw_exec(int optname, void * optval, uintptr_t optlen) {
+	static int sock = -1;
+	int result;
+
+	switch (optname) {
+		case IP_FW_INIT:
+			if (sock == -1)
+				sock = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+			if (sock < 0) {
+				syslog(LOG_ERR, "socket(SOCK_RAW): %m");
+				return -1;
+			}
+			break;
+		case IP_FW_TERM:
+			if (sock != -1)
+				close(sock);
+			sock = -1;
+			break;
+		case IP_FW_ADD:
+		case IP_FW_DEL:
+			result = setsockopt(sock, IPPROTO_IP, optname, optval, optlen);
+			if (result == -1) {
+				syslog(LOG_ERR, "setsockopt(): %m");
+				return -1;
+			}
+			break;
+		case IP_FW_GET:
+			result = getsockopt(sock, IPPROTO_IP, optname, optval, (socklen_t *)optlen);
+			if (result == -1) {
+				syslog(LOG_ERR, "getsockopt(): %m");
+				return -1;
+			}
+			break;
+		default:
+			syslog(LOG_ERR, "unhandled option");
+			return -1;
+	}
+
+	return 0;
+}
+
+void ipfw_free_ruleset(struct ip_fw ** rules) {
+	if (rules == NULL || *rules == NULL)
+		return;
+	free(*rules);
+	*rules = NULL;
+}
+
+int ipfw_fetch_ruleset(struct ip_fw ** rules, int * total_fetched, int count) {
+	int fetched;
+	socklen_t size;
+
+	if (rules == NULL || *total_fetched < 0 || count < 1)
+		return -1;
+
+	size = sizeof(struct ip_fw) * (*total_fetched + count);
+	*rules = (struct ip_fw *)realloc(*rules, size);
+	if (*rules == NULL) {
+		syslog(LOG_ERR, "realloc(): %m");
+		return -1;
+	}
+
+	(*rules)->version = IP_FW_CURRENT_API_VERSION;
+	if (ipfw_exec(IP_FW_GET, *rules, (uintptr_t)&size) < 0)
+		return -1;
+	fetched = *total_fetched;
+	*total_fetched = size / sizeof(struct ip_fw);
+
+	return *total_fetched - fetched;
+}
+
+int ipfw_validate_protocol(int value) {
+	switch (value) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+			break;
+		default:
+			syslog(LOG_ERR, "invalid protocol");
+			return -1;
+	}
+	return 0;
+}
+
+int ipfw_validate_ifname(const char * const value) {
+	int len = strlen(value);
+	if (len < 2 || len > FW_IFNLEN) {
+		syslog(LOG_ERR, "invalid interface name");
+		return -1;
+	}
+	return 0;
+}
+

--- a/miniupnpd/ipfw/ipfwaux.h
+++ b/miniupnpd/ipfw/ipfwaux.h
@@ -2,15 +2,14 @@
 /*
  * MiniUPnP project
  * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
- * (c) 2009 Jardel Weyrich
+ * (c) 2009-2012 Jardel Weyrich
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution
  */
-#ifndef __IPFWAUX_H__
-#define __IPFWAUX_H__
+#ifndef IPFWAUX_H
+#define IPFWAUX_H
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <netinet/in.h>
 #include <netinet/ip_fw.h>
 
@@ -18,96 +17,11 @@
 #define IP_FW_INIT	(IP_FW_BASE + 1)
 #define IP_FW_TERM	(IP_FW_BASE + 2)
 
-static int ipfw_exec(int optname, void * optval, uintptr_t optlen) {
-	static int sock = -1;
-	int result;
-
-	switch (optname) {
-		case IP_FW_INIT:
-			if (sock == -1)
-				sock = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
-			if (sock < 0) {
-				syslog(LOG_ERR, "socket(SOCK_RAW): %m");
-				return -1;
-			}
-			break;
-		case IP_FW_TERM:
-			if (sock != -1)
-				close(sock);
-			sock = -1;
-			break;
-		case IP_FW_ADD:
-		case IP_FW_DEL:
-			result = setsockopt(sock, IPPROTO_IP, optname, optval, optlen);
-			if (result == -1) {
-				syslog(LOG_ERR, "setsockopt(): %m");
-				return -1;
-			}
-			break;
-		case IP_FW_GET:
-			result = getsockopt(sock, IPPROTO_IP, optname, optval, (socklen_t *)optlen);
-			if (result == -1) {
-				syslog(LOG_ERR, "getsockopt(): %m");
-				return -1;
-			}
-			break;
-		default:
-			syslog(LOG_ERR, "unhandled option");
-			return -1;
-	}
-
-	return 0;
-}
-
-static void ipfw_free_ruleset(struct ip_fw ** rules) {
-	if (rules == NULL || *rules == NULL)
-		return;
-	free(*rules);
-	*rules = NULL;
-}
-
-static int ipfw_fetch_ruleset(struct ip_fw ** rules, int * total_fetched, int count) {
-	int fetched;
-	socklen_t size;
-
-	if (rules == NULL || *total_fetched < 0 || count < 1)
-		return -1;
-
-	size = sizeof(struct ip_fw) * (*total_fetched + count);
-	*rules = (struct ip_fw *)realloc(*rules, size);
-	if (*rules == NULL) {
-		syslog(LOG_ERR, "realloc(): %m");
-		return -1;
-	}
-
-	(*rules)->version = IP_FW_CURRENT_API_VERSION;
-	if (ipfw_exec(IP_FW_GET, *rules, (uintptr_t)&size) < 0)
-		return -1;
-	fetched = *total_fetched;
-	*total_fetched = size / sizeof(struct ip_fw);
-
-	return *total_fetched - fetched;
-}
-
-static int ipfw_validate_protocol(int value) {
-	switch (value) {
-		case IPPROTO_TCP:
-		case IPPROTO_UDP:
-			break;
-		default:
-			syslog(LOG_ERR, "invalid protocol");
-			return -1;
-	}
-	return 0;
-}
-
-static int ipfw_validate_ifname(const char * const value) {
-	int len = strlen(value);
-	if (len < 2 || len > FW_IFNLEN) {
-		syslog(LOG_ERR, "invalid interface name");
-		return -1;
-	}
-	return 0;
-}
+int ipfw_exec(int optname, void * optval, uintptr_t optlen);
+void ipfw_free_ruleset(struct ip_fw ** rules);
+int ipfw_fetch_ruleset(struct ip_fw ** rules, int * total_fetched, int count);
+int ipfw_validate_protocol(int value);
+int ipfw_validate_ifname(const char * const value);
 
 #endif
+


### PR DESCRIPTION
**1. Rename IPFW include guards to not infringe the C standard rules.**

Quoting § 7.1.3 (Reserved identifiers) ¶ 1 from the C99 standard:

> Each header declares or defines all identifiers listed in its associated subclause, and optionally declares or defines identifiers listed in its associated future library directions subclause and identifiers which are always reserved either for any use or for use as file scope identifiers.
> **— All identifiers that begin with an underscore and either an uppercase letter or another underscore are always reserved for any use.**
> — All identifiers that begin with an underscore are always reserved for use as identifiers with file scope in both the ordinary and tag name spaces.
> — Each macro name in any of the following subclauses (including the future library directions) is reserved for use as specified if any of its associated headers is included; unless explicitly stated otherwise (see 7.1.4).
> — All identifiers with external linkage in any of the following subclauses (including the future library directions) are always reserved for use as identifiers with external linkage.160)
> — Each identifier with file scope listed in any of the following subclauses (including the future library directions) is reserved for use as a macro name and as an identifier with file scope in the same name space if any of its associated headers is included.

Should we update all other include guards as well?

**2. Move IPFW implementation to a source file. Static in headers is not good.**

Having that _static sock_ will cause problems when multiple translations units include `ipfwaux.h`. For example:
- `unit1.c` calls `ipfw_exec` with `optname = IP_FW_INIT`.
- `unit2.c` calls `ipfw_exec` to perform any other operation.
  Then `unit2.c` will fail, because each translation unit will have its own static variables, therefore the _static sock_ compiled in `unit2.c` was not initialized.

Please, let me know your thoughts.
