### PR TITLE
Allow LIBDIR override and IPv6 opt out

### DIFF
--- a/miniupnpc/Makefile
+++ b/miniupnpc/Makefile
@@ -20,6 +20,9 @@ ifeq ($(OS), Linux)
 JARSUFFIX=linux
 endif
 
+HAVE_IPV6 ?= yes
+export HAVE_IPV6
+
 CC ?= gcc
 #AR = gar
 #CFLAGS = -O -g -DDEBUG
@@ -99,10 +102,11 @@ TESTMINIWGETOBJS := $(TESTMINIWGETOBJS) minissdpc.o
 TESTIGDDESCPARSE := $(TESTIGDDESCPARSE) minissdpc.o
 endif
 
+LIBDIR ?= lib
 # install directories
 INSTALLPREFIX ?= $(PREFIX)/usr
 INSTALLDIRINC = $(INSTALLPREFIX)/include/miniupnpc
-INSTALLDIRLIB = $(INSTALLPREFIX)/lib
+INSTALLDIRLIB = $(INSTALLPREFIX)/$(LIBDIR)
 INSTALLDIRBIN = $(INSTALLPREFIX)/bin
 INSTALLDIRMAN = $(INSTALLPREFIX)/share/man
 

--- a/miniupnpc/testminiwget.sh
+++ b/miniupnpc/testminiwget.sh
@@ -19,16 +19,26 @@ TMPDIR=`mktemp -d`
 HTTPSERVEROUT="${TMPDIR}/httpserverout"
 EXPECTEDFILE="${TMPDIR}/expectedfile"
 DOWNLOADEDFILE="${TMPDIR}/downloadedfile"
-#ADDR=localhost
-ADDR="[::1]"
 PORT=
 RET=0
+
+case "$HAVE_IPV6" in
+    n|no|0)
+        ADDR=localhost
+        SERVERARGS=""
+        ;;
+    *)
+        ADDR="[::1]"
+        SERVERARGS="-6"
+        ;;
+
+esac
 
 #make minihttptestserver
 #make testminiwget
 
 # launching the test HTTP server
-./minihttptestserver -6 -e $EXPECTEDFILE > $HTTPSERVEROUT &
+./minihttptestserver $SERVERARGS -e $EXPECTEDFILE > $HTTPSERVEROUT &
 while [ -z "$PORT" ]; do
 	sleep 1
 	PORT=`cat $HTTPSERVEROUT | sed 's/Listening on port \([0-9]*\)/\1/' `


### PR DESCRIPTION
For proper installing miniupnpc in [Exherbo](http://www.exherbo.org) it will be good to have these changes or similar in upstream code.
The reason for this patch is that at 64bit platform where .../lib64 is used we need to have a chance to override default .../lib variant. Also when there is no IPv6 support enabled one of the tests hangs:

```
miniwget validation test
./testminiwget.sh
socket: Address family not supported by protocol
```

Thank you
