### PR TITLE
fix cross-compile:   some libc implementations don't define struct ip_mreqn

### DIFF
--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -71,6 +71,17 @@
 #define TIMEVAL struct timeval
 #endif
 
+
+#if defined(HAS_IP_MREQN) && defined(NEED_STRUCT_IP_MREQN)
+/* Several versions of glibc don't define this structure, define it here and compile with CFLAGS NEED_STRUCT_IP_MREQN */
+struct ip_mreqn
+{
+	struct in_addr	imr_multiaddr;		/* IP multicast address of group */
+	struct in_addr	imr_address;		/* local IP address of interface */
+	int		imr_ifindex;		/* Interface index */
+};
+#endif
+
 #include "miniupnpc.h"
 #include "minissdpc.h"
 #include "miniwget.h"


### PR DESCRIPTION
some libc implementations don't define struct ip_mreqn
define it here if CFLAG passed with -DNEED_STRUCT_IP_MREQN

I found this issue cross compiling for ARM using eclibc in the
https://www.yoctoproject.org/  build system.

without this patch, my build fails:
 arm-poky-linux-gnueabi-gcc  -march=armv6 -mthumb-interwork -mfloat-abi=softfp --sysroot=/home/karl/Work/yocto/poky/build_mvs/tmp/sysroots/my_board -O2 -pipe -g -feliminate-unused-debug-types   -c -o miniupnpc.o miniupnpc.c
miniupnpc.c: In function 'upnpDiscover':
miniupnpc.c:517:21: error: storage size of 'reqn' isn't known
