### PR TITLE
miniupnpd/natpmp.c: return correct error code when all external ports in...

### DIFF
--- a/miniupnpd/natpmp.c
+++ b/miniupnpd/natpmp.c
@@ -291,7 +291,7 @@ void ProcessIncomingNATPMPPacket(int s, unsigned char *msg_buff, int len,
 							if(eport == eport_first) { /* no external port available */
 								syslog(LOG_ERR, "Failed to find available eport for NAT-PMP %hu %s->%s:%hu",
 								       eport, (proto==IPPROTO_TCP)?"tcp":"udp", senderaddrstr, iport);
-								resp[3] = 3;  /* Failure */
+								resp[3] = 4;  /* Out of resources */
 								break;
 							}
 							continue;


### PR DESCRIPTION
... use

Instead of returning code 3 ("Network Failure"), we should the
more appropriate code 4 ("Out of resources") when no external
port is available for a mapping.
