### PR TITLE
miniupnpd: add support for "busy" permission type

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1352,10 +1352,11 @@ print_usage:
 			"\t-n sets the name of the interface(s) that packets will arrive on.\n"
 #endif
 			"\t-A use following syntax for permission rules :\n"
-			"\t  (allow|deny) (external port range) ip/mask (internal port range)\n"
+			"\t  (allow|deny|busy) (external port range) ip/mask (internal port range)\n"
 			"\texamples :\n"
 			"\t  \"allow 1024-65535 192.168.1.0/24 1024-65535\"\n"
 			"\t  \"deny 0-65535 0.0.0.0/0 0-65535\"\n"
+			"\t  \"busy 22 0.0.0.0/0\"\n"
 			"\t-h prints this help and quits.\n"
 	        "", argv[0], pidfilename, DEFAULT_CONFIG);
 	return 1;

--- a/miniupnpd/testupnppermissions.c
+++ b/miniupnpd/testupnppermissions.c
@@ -23,6 +23,9 @@ print_upnpperm(const struct upnpperm * p)
 	case UPNPPERM_DENY:
 		printf("deny ");
 		break;
+	case UPNPPERM_BUSY:
+		printf("busy ");
+		break;
 	default:
 		printf("error ! ");
 	}

--- a/miniupnpd/upnppermissions.h
+++ b/miniupnpd/upnppermissions.h
@@ -17,7 +17,7 @@
  * allow 1024-65535 192.168.3.0/24 1024-65535
  * deny 0-65535 192.168.1.125/32 0-65535 */
 struct upnpperm {
-	enum {UPNPPERM_ALLOW=1, UPNPPERM_DENY=2 } type;
+	enum {UPNPPERM_ALLOW=1, UPNPPERM_DENY=2, UPNPPERM_BUSY=3 } type;
 				/* is it an allow or deny permission rule ? */
 	u_short eport_min, eport_max;	/* external port range */
 	struct in_addr address, mask;	/* ip/mask */
@@ -44,6 +44,15 @@ check_upnp_rule_against_permissions(const struct upnpperm * permary,
                                     int n_perms,
                                     u_short eport, struct in_addr address,
                                     u_short iport);
+
+/* get_permission_type_for_upnp_rule()
+ * returns: permission type (UPNPPERM_ALLOW|UPNPPERM_DENY|UPNPPERM_BUSY) if a permission matching the upnp rule exists,
+ *          UPNPPERM_ALLOW if no matching permission exists */
+int
+get_permission_type_for_upnp_rule(const struct upnpperm * permary,
+                                  int n_perms,
+                                  u_short eport, struct in_addr address,
+                                  u_short iport);
 
 #ifdef USE_MINIUPNPDCTL
 void


### PR DESCRIPTION
This change introduces a third permission type, "busy." For UPnP and
(currently) PCP, these rules have the exact same effect as "deny"
rules. However, for NAT-PMP, matching a "busy" rule will not cause
miniupnpd to return an error response, but rather will cause it to try
and assign a different external port. This is intended to support the
behavior required by section 3.3 of the NAT-PMP specification for the
case where the requested external port is already in use by another
mapping ("If that external port is not available, the NAT gateway MUST
return an available external port if possible, or return an error code
if no external ports are available.").
