### PR TITLE
miniupnpd/pcpserver.c: return error code if PCP mapping fails

### DIFF
--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -897,6 +897,8 @@ static void CreatePCPMap(pcp_info_t *pcp_msg_info)
 		        pcp_msg_info->int_port,
 		        desc);
 
+		pcp_msg_info->result_code = PCP_ERR_NO_RESOURCES;
+
 	} else {
 		syslog(LOG_INFO, "PCP MAP: added mapping %s %hu->%s:%hu '%s'",
 		        (pcp_msg_info->protocol==IPPROTO_TCP)?"TCP":"UDP",


### PR DESCRIPTION
This change causes CreatePCPMap to return a PCP_ERR_NO_RESOURCES
response when upnp_redirect_internal does not succeed;
previously, no error code was returned in this case.
