### PR TITLE
Added ipv6_listening_ip option to override it from in6addr_any.

### DIFF
--- a/miniupnpd/minissdp.c
+++ b/miniupnpd/minissdp.c
@@ -116,13 +116,18 @@ OpenAndConfSSDPReceiveSocket(int ipv6)
 	}
 
 	memset(&sockname, 0, sizeof(struct sockaddr_storage));
-	if(ipv6) {
+#ifdef ENABLE_IPV6
+	if(ipv6)
+	{
 		struct sockaddr_in6 * saddr = (struct sockaddr_in6 *)&sockname;
 		saddr->sin6_family = AF_INET6;
 		saddr->sin6_port = htons(SSDP_PORT);
-		saddr->sin6_addr = in6addr_any;
+		saddr->sin6_addr = ipv6_bind_addr;
 		sockname_len = sizeof(struct sockaddr_in6);
-	} else {
+	}
+	else
+#endif /* ENABLE_IPV6 */
+	{
 		struct sockaddr_in * saddr = (struct sockaddr_in *)&sockname;
 		saddr->sin_family = AF_INET;
 		saddr->sin_port = htons(SSDP_PORT);

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -164,7 +164,7 @@ OpenAndConfHTTPSocket(unsigned short port)
 		memset(&listenname6, 0, sizeof(struct sockaddr_in6));
 		listenname6.sin6_family = AF_INET6;
 		listenname6.sin6_port = htons(port);
-		listenname6.sin6_addr = in6addr_any;
+		listenname6.sin6_addr = ipv6_bind_addr;
 		listenname_len =  sizeof(struct sockaddr_in6);
 	} else {
 		memset(&listenname4, 0, sizeof(struct sockaddr_in));
@@ -833,6 +833,9 @@ init(int argc, char * * argv, struct runtime_vars * v)
 
 	/* set initial values */
 	SETFLAG(ENABLEUPNPMASK);	/* UPnP is enabled by default */
+#ifdef ENABLE_IPV6
+	ipv6_bind_addr = in6addr_any;
+#endif /* ENABLE_IPV6 */
 
 	LIST_INIT(&lan_addrs);
 	v->port = -1;
@@ -878,6 +881,14 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				}
 				LIST_INSERT_HEAD(&lan_addrs, lan_addr, list);
 				break;
+#ifdef ENABLE_IPV6
+			case UPNPIPV6_LISTENING_IP:
+				if (inet_pton(AF_INET6, ary_options[i].value, &ipv6_bind_addr) < 1)
+				{
+					fprintf(stderr, "can't parse \"%s\" as valid IPv6 listening address", ary_options[i].value);
+				}
+				break;
+#endif /* ENABLE_IPV6 */
 			case UPNPPORT:
 				v->port = atoi(ary_options[i].value);
 				break;

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -31,6 +31,9 @@ static const struct {
 	{ UPNPEXT_IFNAME, "ext_ifname" },
 	{ UPNPEXT_IP,	"ext_ip" },
 	{ UPNPLISTENING_IP, "listening_ip" },
+#ifdef ENABLE_IPV6
+	{ UPNPIPV6_LISTENING_IP, "ipv6_listening_ip" },
+#endif /* ENABLE_IPV6 */
 	{ UPNPPORT, "port" },
 	{ UPNPPORT, "http_port" },	/* "port" and "http_port" are synonims */
 #ifdef ENABLE_HTTPS

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -18,6 +18,9 @@ enum upnpconfigoptions {
 	UPNPEXT_IFNAME = 1,		/* ext_ifname */
 	UPNPEXT_IP,				/* ext_ip */
 	UPNPLISTENING_IP,		/* listening_ip */
+#ifdef ENABLE_IPV6
+	UPNPIPV6_LISTENING_IP,		/* listening address for IPv6 */
+#endif /* ENABLE_IPV6 */
 	UPNPPORT,				/* "port" / "http_port" */
 #ifdef ENABLE_HTTPS
 	UPNPHTTPSPORT,			/* "https_port" */

--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -1642,7 +1642,7 @@ int OpenAndConfPCPv6Socket(void)
 	memset(&addr, 0, sizeof(addr));
 	addr.sin6_family = AF_INET6;
 	addr.sin6_port = htons(NATPMP_PORT);
-	addr.sin6_addr = in6addr_any;
+	addr.sin6_addr = ipv6_bind_addr;
 	if(bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		syslog(LOG_ERR, "%s: bind(): %m", "OpenAndConfPCPv6Socket");
 		close(s);

--- a/miniupnpd/upnpglobalvars.c
+++ b/miniupnpd/upnpglobalvars.c
@@ -110,6 +110,9 @@ struct lan_addr_list lan_addrs;
 #ifdef ENABLE_IPV6
 /* ipv6 address used for HTTP */
 char ipv6_addr_for_http_with_brackets[64];
+
+/* address used to bind local services */
+struct in6_addr ipv6_bind_addr;
 #endif
 
 /* Path of the Unix socket used to communicate with MiniSSDPd */

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -140,6 +140,10 @@ extern struct lan_addr_list lan_addrs;
 #ifdef ENABLE_IPV6
 /* ipv6 address used for HTTP */
 extern char ipv6_addr_for_http_with_brackets[64];
+
+/* address used to bind local services */
+extern struct in6_addr ipv6_bind_addr;
+
 #endif
 
 extern const char * minissdpdsocketpath;


### PR DESCRIPTION
This way IPv6 services can be selectively enabled on one IP too.

This is useful if you don't want to firewall service, but just e.g. bind to bridge IPv6 address, or ::1 if you want to handle externally protocols elsewhere.

(I think multiple statically configured IPv6 addresses is not probably sensible, but this is a low-hanging fruit that I needed for a project.)
