### PR TITLE
netfilter: Linux 3.10(?) IPv6 firewall pinhole fix

### DIFF
--- a/miniupnpd/netfilter/iptpinhole.c
+++ b/miniupnpd/netfilter/iptpinhole.c
@@ -206,6 +206,8 @@ int add_pinhole(const char * ifname,
 
 	e = calloc(1, sizeof(struct ip6t_entry));
 	e->ipv6.proto = proto;
+	if (proto)
+		e->ipv6.flags |= IP6T_F_PROTO;
 
 	if(ifname)
 		strncpy(e->ipv6.iniface, ifname, IFNAMSIZ);


### PR DESCRIPTION
For some reason, rules without ipv6.flags set (and proto set?) do not match at all at least on Linux 3.10. So with this patch, they do (and it took me a while to find out, sigh)
