### PR TITLE
miniupnpd/pcpserver.c: ext_port field was not set in the (IPv6) firewall reply packet

### DIFF
--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -1020,6 +1020,7 @@ static int CreatePCPMap_FW(pcp_info_t *pcp_msg_info)
 					&uid);
 	if (r < 0)
 		return PCP_ERR_NO_RESOURCES;
+	pcp_msg_info->ext_port = pcp_msg_info->int_port;
 	return PCP_SUCCESS;
 #else
 	return PCP_ERR_NO_RESOURCES;


### PR DESCRIPTION
.. found a bug in the code I added when writing test-suite for PCP stuff on OpenWrt ;) (probably more to come, if I get ambitious testing this)
