### PR TITLE
Use built-in __APPLE__ macro instead of MACOSX

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -36,7 +36,7 @@ else (NOT WIN32)
 endif (NOT WIN32)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  add_definitions (-DMACOSX -D_DARWIN_C_SOURCE)
+  add_definitions (-D_DARWIN_C_SOURCE)
 endif ()
 
 # Set compiler specific build flags

--- a/miniupnpc/Makefile
+++ b/miniupnpc/Makefile
@@ -85,7 +85,7 @@ LIBRARY = libminiupnpc.a
 ifeq ($(OS), Darwin)
   SHAREDLIBRARY = libminiupnpc.dylib
   SONAME = $(basename $(SHAREDLIBRARY)).$(APIVERSION).dylib
-  CFLAGS := -DMACOSX -D_DARWIN_C_SOURCE $(CFLAGS)
+  CFLAGS := -D_DARWIN_C_SOURCE $(CFLAGS)
 else
 ifeq ($(JARSUFFIX), win32)
   SHAREDLIBRARY = miniupnpc.dll

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -6,7 +6,7 @@
  * This software is subjet to the conditions detailed in the
  * provided LICENSE file. */
 #define __EXTENSIONS__ 1
-#if !defined(MACOSX) && !defined(__sun)
+#if !defined(__APPLE__) && !defined(__sun)
 #if !defined(_XOPEN_SOURCE) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #ifndef __cplusplus
 #define _XOPEN_SOURCE 600
@@ -17,7 +17,7 @@
 #endif
 #endif
 
-#if !defined(__DragonFly__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(MACOSX) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__sun)
+#if !defined(__DragonFly__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__APPLE__) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__sun)
 #define HAS_IP_MREQN
 #endif
 

--- a/miniupnpd/Makefile.macosx
+++ b/miniupnpd/Makefile.macosx
@@ -20,8 +20,6 @@ MV = mv
 INSTALL = install
 STRIP = strip
 
-CFLAGS += -DMACOSX
-
 # OSNAME and FWNAME are used for building OS or FW dependent code.
 OSNAME = $(shell uname)
 ARCH = $(shell uname -p)

--- a/miniupnpd/pf/obsdrdr.c
+++ b/miniupnpd/pf/obsdrdr.c
@@ -49,7 +49,7 @@
 #ifdef __DragonFly__
 #include <net/pf/pfvar.h>
 #else
-#ifdef MACOSX
+#ifdef __APPLE__
 #define PRIVATE 1
 #endif
 #include <net/pfvar.h>
@@ -269,7 +269,7 @@ add_redirect_rule2(const char * ifname,
 		pcr.rule.rdr.addr.type = PF_ADDR_ADDRMASK;
 #endif
 
-#ifdef MACOSX
+#ifdef __APPLE__
 		pcr.rule.dst.xport.range.op = PF_OP_EQ;
 		pcr.rule.dst.xport.range.port[0] = htons(eport);
 		pcr.rule.dst.xport.range.port[1] = htons(eport);
@@ -528,7 +528,7 @@ get_redirect_rule(const char * ifname, unsigned short eport, int proto,
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
 			goto error;
 		}
-#ifdef MACOSX
+#ifdef __APPLE__
 		if( (eport == ntohs(pr.rule.dst.xport.range.port[0]))
 		  && (eport == ntohs(pr.rule.dst.xport.range.port[1]))
 #else
@@ -636,7 +636,7 @@ priv_delete_redirect_rule(const char * ifname, unsigned short eport,
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
 			goto error;
 		}
-#ifdef MACOSX
+#ifdef __APPLE__
 		if( (eport == ntohs(pr.rule.dst.xport.range.port[0]))
 		  && (eport == ntohs(pr.rule.dst.xport.range.port[1]))
 #else
@@ -830,7 +830,7 @@ get_redirect_rule_by_index(int index,
 		goto error;
 	}
 	*proto = pr.rule.proto;
-#ifdef MACOSX
+#ifdef __APPLE__
 	*eport = ntohs(pr.rule.dst.xport.range.port[0]);
 #else
 	*eport = ntohs(pr.rule.dst.port[0]);
@@ -946,7 +946,7 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
 			continue;
 		}
-#ifdef MACOSX
+#ifdef __APPLE__
 		eport = ntohs(pr.rule.dst.xport.range.port[0]);
 		if( (eport == ntohs(pr.rule.dst.xport.range.port[1]))
 #else

--- a/miniupnpd/pf/pfpinhole.c
+++ b/miniupnpd/pf/pfpinhole.c
@@ -15,7 +15,7 @@
 #ifdef __DragonFly__
 #include <net/pf/pfvar.h>
 #else
-#ifdef MACOSX
+#ifdef __APPLE__
 #define PRIVATE 1
 #endif
 #include <net/pfvar.h>


### PR DESCRIPTION
GCC and Clang on Mac OS have a built-in `__APPLE__` macro. Use it instead of
manually-defined `MACOSX`.
