### PR TITLE
Use _WIN32 instead of WIN32 to check for Windows

### DIFF
--- a/miniupnpc/msvc/miniupnpc.vcproj
+++ b/miniupnpc/msvc/miniupnpc.vcproj
@@ -41,7 +41,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;MINIUPNP_STATICLIB;DEBUG"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;MINIUPNP_STATICLIB;DEBUG"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -104,7 +104,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;WIN32;MINIUPNP_STATICLIB"
+				PreprocessorDefinitions="_CRT_SECURE_NO_WARNINGS;MINIUPNP_STATICLIB"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"

--- a/miniupnpc/msvc/upnpc-static.vcproj
+++ b/miniupnpc/msvc/upnpc-static.vcproj
@@ -41,7 +41,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE;MINIUPNP_STATICLIB;DEBUG;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="_DEBUG;_CONSOLE;MINIUPNP_STATICLIB;DEBUG;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -115,7 +115,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;MINIUPNP_STATICLIB"
+				PreprocessorDefinitions="NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;MINIUPNP_STATICLIB"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"

--- a/miniupnpd/pcp_msg_struct.h
+++ b/miniupnpd/pcp_msg_struct.h
@@ -135,10 +135,10 @@ typedef enum pcp_options  {
 } pcp_options_t;
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning (push)
 #pragma warning (disable:4200)
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #pragma pack(push, 1)
 
@@ -285,6 +285,6 @@ typedef struct pcp_filter_option {
 
 #pragma pack(pop)
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning (pop)
-#endif /* WIN32 */
+#endif /* _WIN32 */


### PR DESCRIPTION
MinGW defines both _WIN32 and WIN32 (and may even be the only compiler
doing so). Microsoft and Intel compilers only define _WIN32. Use the
common one to eliminate the need in defining WIN32 explicitly.
