### PR TITLE
Repair python3 build under Homebrew Python 3.4 with OSX 10.9.

### DIFF
--- a/miniupnpc/.gitignore
+++ b/miniupnpc/.gitignore
@@ -8,6 +8,7 @@ build/
 Makefile.bak
 miniupnpcstrings.h
 pythonmodule
+pythonmodule3
 upnpc-shared
 upnpc-static
 minihttptestserver

--- a/miniupnpc/miniupnpcmodule.c
+++ b/miniupnpc/miniupnpcmodule.c
@@ -599,7 +599,7 @@ initminiupnpc(void)
     UPnPType.tp_new = PyType_GenericNew;
 #endif
     if (PyType_Ready(&UPnPType) < 0)
-        return;
+        return 0;
 
 #if PY_MAJOR_VERSION >= 3
     m = PyModule_Create(&moduledef);
@@ -610,7 +610,7 @@ initminiupnpc(void)
 
     Py_INCREF(&UPnPType);
     PyModule_AddObject(m, "UPnP", (PyObject *)&UPnPType);
-    
+
 #if PY_MAJOR_VERSION >= 3
     return m;
 #endif


### PR DESCRIPTION
Environment

``` bash
$ uname -a
Darwin whale.local 13.2.0 Darwin Kernel Version 13.2.0: Thu Apr 17 23:03:13 PDT 2014; root:xnu-2422.100.13~1/RELEASE_X86_64 x86_64
$ brew info python3
python3: stable 3.4.1 (bottled), HEAD
https://www.python.org/
/usr/local/Cellar/python3/3.4.1 (3994 files, 68M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/commits/master/Library/Formula/python3.rb
==> Dependencies
Build: pkg-config ✔
Required: openssl ✔
Recommended: readline ✔, sqlite ✔, gdbm ✔, xz ✔
```

Output

``` bash
$ make pythonmodule3
...
python3 setup.py build
running build
running build_ext
building 'miniupnpc' extension
creating build
creating build/temp.macosx-10.9-x86_64-3.4
clang -I/usr/local/Cellar/python3/3.4.1/Frameworks/Python.framework/Versions/3.4/include/python3.4m -c miniupnpcmodule.c -o build/temp.macosx-10.9-x86_64-3.4/miniupnpcmodule.o
miniupnpcmodule.c:602:9: error: non-void function 'PyInit_miniupnpc' should
      return a value [-Wreturn-type]
        return;
        ^
1 error generated.
error: command 'clang' failed with exit status 1
make: *** [pythonmodule3] Error 1
```
