### PR TITLE
Dynamic build fails

### DIFF
--- a/miniupnpc/miniupnpc.def
+++ b/miniupnpc/miniupnpc.def
@@ -24,7 +24,9 @@ EXPORTS
    UPNP_GetExternalIPAddress
    UPNP_GetLinkLayerMaxBitRates
    UPNP_AddPortMapping
+   UPNP_AddAnyPortMapping
    UPNP_DeletePortMapping
+   UPNP_DeletePortMappingRange
    UPNP_GetPortMappingNumberOfEntries
    UPNP_GetSpecificPortMappingEntry
    UPNP_GetGenericPortMappingEntry


### PR DESCRIPTION
Dynamic build fails as a result of undefined reference for UPNP_AddAnyPortMapping and UPNP_DeletePortMappingRange
