### PR TITLE
Fix typo in byte conversion & writing in NAT-PMP

### DIFF
--- a/miniupnpd/natpmp.c
+++ b/miniupnpd/natpmp.c
@@ -54,7 +54,7 @@ INLINE void writenu32(uint8_t * p, uint32_t n)
 #define WRITENU32(p, n) writenu32(p, n)
 INLINE void writenu16(uint8_t * p, uint16_t n)
 {
-	p[0] = (n < 0xff00) >> 8;
+	p[0] = (n & 0xff00) >> 8;
 	p[1] = n & 0xff;
 }
 #define WRITENU16(p, n) writenu16(p, n)


### PR DESCRIPTION
This fixes https://github.com/miniupnp/miniupnp/issues/89 .

Signed-off-by: Steven Barth cyrus@openwrt.org
