### PR TITLE
Remove unnecessary sysctl.h include for linux

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -39,7 +39,7 @@
 #include <sys/param.h>
 #if defined(sun)
 #include <kstat.h>
-#else
+#elif !defined(__linux__)
 /* for BSD's sysctl */
 #include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
miniupnpd on Linux unnecessarily includes sys/sysctl.h which breaks builds with musl-libc.

Signed-off-by: Steven Barth cyrus@openwrt.org
