### PR TITLE
UPNP pinholing: add missing sys/types.h include

### DIFF
--- a/miniupnpd/netfilter/iptpinhole.h
+++ b/miniupnpd/netfilter/iptpinhole.h
@@ -8,6 +8,7 @@
 #define IPTPINHOLE_H_INCLUDED
 
 #ifdef ENABLE_UPNPPINHOLE
+#include <sys/types.h>
 
 int add_pinhole(const char * ifname,
                 const char * rem_host, unsigned short rem_port,


### PR DESCRIPTION
sys/types.h is necessary to declare u_int64_t for some c libraries, so include it.

Signed-off-by: Steven Barth cyrus@openwrt.org
