### PR TITLE
Fix setsockopt() for IPV6_MULTICAST_IF

### DIFF
--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -510,7 +510,7 @@ upnpDiscover(int delay, const char * multicastif,
 			 * MS Windows Vista and MS Windows Server 2008.
 			 * http://msdn.microsoft.com/en-us/library/bb408409%28v=vs.85%29.aspx */
 			unsigned int ifindex = if_nametoindex(multicastif); /* eth0, etc. */
-			if(setsockopt(sudp, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(&ifindex)) < 0)
+			if(setsockopt(sudp, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) < 0)
 			{
 				PRINT_SOCKET_ERROR("setsockopt");
 			}


### PR DESCRIPTION
32bit: sizeof(&ifindex) == sizeof(void *) == 4
64bit: sizeof(&ifindex) == sizeof(void *) == 8

As a result, it is "ifindex" oob acces on 64bit platforms.