### PR TITLE
Fix get_portmappings_in_range() in non-expand case.

### DIFF
--- a/miniupnpd/netfilter/iptcrdr.c
+++ b/miniupnpd/netfilter/iptcrdr.c
@@ -1434,9 +1434,9 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 							break;
 						}
 						array = tmp;
-						array[*number] = eport;
-						(*number)++;
 					}
+					array[*number] = eport;
+					(*number)++;
 				}
 			}
 		}


### PR DESCRIPTION
In get_portmappings_in_range(), array[] is not updated when realloc() is not called, 
hence get_portmappings_in_range() is always null.  This fix changes to fill array[].