### PR TITLE
Fix MINIUPNP_STATICLIB being lost in CMake configuration

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -86,8 +86,7 @@ endif (NOT WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
 
 if (WIN32)
   set_source_files_properties (${MINIUPNPC_SOURCES} PROPERTIES
-                                                    COMPILE_DEFINITIONS MINIUPNP_STATICLIB
-                                                    COMPILE_DEFINITIONS MINIUPNP_EXPORTS
+                                                    COMPILE_DEFINITIONS "MINIUPNP_STATICLIB;MINIUPNP_EXPORTS"
   )
 endif (WIN32)
 


### PR DESCRIPTION
Each `COMPILE_DEFINITIONS` passed to `set_source_file_properties ()` overrides previous value, so only `MINIUPNP_EXPORTS` is left in the end. Pass single `COMPILE_DEFINITIONS` and combine needed definitions into `;`-separated list manually.