### PR TITLE
Add option "-b" for redirect port X to port Y to 'this' system

### DIFF
--- a/miniupnpc/Changelog.txt
+++ b/miniupnpc/Changelog.txt
@@ -1,5 +1,8 @@
-$Id: Changelog.txt,v 1.202 2014/11/17 19:10:28 nanard Exp $
+$Id: Changelog.txt,v 1.202 2015/04/21 21:21:21 nanard Exp $
 miniUPnP client Changelog.
+
+2015/04/21:
+  Add option "-b" for redirect port X to port Y on the system issueing the command
 
 2014/11/17:
   search all :

--- a/miniupnpc/upnpc.c
+++ b/miniupnpc/upnpc.c
@@ -577,7 +577,9 @@ int main(int argc, char ** argv)
 		}
 	}
 
-	if(!command || (command == 'a' && commandargc<4)
+	if(!command 
+           || (command == 'a' && commandargc<4)
+	   || (command == 'b' && commandargc<3)
 	   || (command == 'd' && argc<2)
 	   || (command == 'r' && argc<2)
 	   || (command == 'A' && commandargc<6)
@@ -585,6 +587,7 @@ int main(int argc, char ** argv)
 	   || (command == 'D' && commandargc<1))
 	{
 		fprintf(stderr, "Usage :\t%s [options] -a ip port external_port protocol [duration]\n\t\tAdd port redirection\n", argv[0]);
+		fprintf(stderr, "       \t%s [options] -b port external_port protocol [duration]\n\t\tAdd port redirection to this system\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -d external_port protocol <remote host>\n\t\tDelete port redirection\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -s\n\t\tGet Connection status\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -l\n\t\tList redirections\n", argv[0]);
@@ -675,6 +678,13 @@ int main(int argc, char ** argv)
 						   commandargv[0], commandargv[1],
 						   commandargv[2], commandargv[3],
 						   (commandargc > 4)?commandargv[4]:"0",
+						   description, 0);
+				break;
+			case 'b':
+				SetRedirectAndTest(&urls, &data,
+						   lanaddr, commandargv[0],
+						   commandargv[1], commandargv[2],
+						   (commandargc > 3)?commandargv[3]:"0",
 						   description, 0);
 				break;
 			case 'd':

--- a/miniupnpc/upnpc.c
+++ b/miniupnpc/upnpc.c
@@ -41,6 +41,20 @@ const char * protofix(const char * proto)
 	return 0;
 }
 
+/* is_int() checks if parameter is an integer or not
+ * 1 for integer
+ * 0 for not an integer */
+int is_int(char const* s) {
+	int i,n;
+	if(s){
+		return sscanf(s, "%d %n", &i, &n) == 1 && !s[n];
+	}else{
+		return(0);	/* null as input, so not an integer ... */
+	}
+}
+
+
+
 static void DisplayInfos(struct UPNPUrls * urls,
                          struct IGDdatas * data)
 {
@@ -578,7 +592,7 @@ int main(int argc, char ** argv)
 	}
 
 	if(!command 
-           || (command == 'a' && commandargc<4)
+	   || (command == 'a' && commandargc<4)
 	   || (command == 'b' && commandargc<3)
 	   || (command == 'd' && argc<2)
 	   || (command == 'r' && argc<2)
@@ -594,7 +608,7 @@ int main(int argc, char ** argv)
 		fprintf(stderr, "       \t%s [options] -L\n\t\tList redirections (using GetListOfPortMappings (for IGD:2 only)\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -n ip port external_port protocol [duration]\n\t\tAdd (any) port redirection allowing IGD to use alternative external_port (for IGD:2 only)\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -N external_port_start external_port_end protocol [manage]\n\t\tDelete range of port redirections (for IGD:2 only)\n", argv[0]);
-		fprintf(stderr, "       \t%s [options] -r port1 protocol1 [port2 protocol2] [...]\n\t\tAdd all redirections to the current host\n", argv[0]);
+		fprintf(stderr, "       \t%s [options] -r port1 [external_port1] protocol1 [port2 [external_port2] protocol2] [...]\n\t\tAdd all redirections to the current host\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -A remote_ip remote_port internal_ip internal_port protocol lease_time\n\t\tAdd Pinhole (for IGD:2 only)\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -U uniqueID new_lease_time\n\t\tUpdate Pinhole (for IGD:2 only)\n", argv[0]);
 		fprintf(stderr, "       \t%s [options] -C uniqueID\n\t\tCheck if Pinhole is Working (for IGD:2 only)\n", argv[0]);
@@ -709,13 +723,24 @@ int main(int argc, char ** argv)
 				GetConnectionStatus(&urls, &data);
 				break;
 			case 'r':
-				for(i=0; i<commandargc; i+=2)
-				{
-					/*printf("port %s protocol %s\n", argv[i], argv[i+1]);*/
-					SetRedirectAndTest(&urls, &data,
-							   lanaddr, commandargv[i],
-							   commandargv[i], commandargv[i+1], "0",
-							   description, 0);
+				i=0;
+				while(i<commandargc){
+					if(!is_int(commandargv[i+1])){
+						/* 2nd parameter not an integer, so format is '<port> <protocol>' */
+						/* Note: no 2nd parameter is also not-an-integer, and will lead to a "Wrong arguments" */
+						SetRedirectAndTest(&urls, &data,
+								   lanaddr, commandargv[i],
+								   commandargv[i], commandargv[i+1], "0",
+								   description, 0);
+						i+=2;	/* 2 parameters parsed */
+					} else {
+						/* 2nd parameter is an integer, so format is '<port> <extport> <protocol>' */
+						SetRedirectAndTest(&urls, &data,
+								   lanaddr, commandargv[i],
+								   commandargv[i+1], commandargv[i+2], "0",
+								   description, 0);
+						i+=3;	/* 3 parameters parsed */
+					}
 				}
 				break;
 			case 'A':


### PR DESCRIPTION
Add option "-b" for redirect port X to port Y to 'this' system (= system issuing the UPnP command).

See https://github.com/miniupnp/miniupnp/issues/104