### PR TITLE
Specify interface and other params in python module

### DIFF
--- a/miniupnpc/miniupnpcmodule.c
+++ b/miniupnpc/miniupnpcmodule.c
@@ -58,7 +58,7 @@ static PyMemberDef UPnP_members[] = {
 	{"multicastif", T_STRING, offsetof(UPnPObject, multicastif),
 	 0, "IP of the network interface to be used for multicast operations"
 	},
-	{"minissdpdsocket", T_STRING, offsetof(UPnPObject, multicastif),
+	{"minissdpdsocket", T_STRING, offsetof(UPnPObject, minissdpdsocket),
 	 0, "path of the MiniSSDPd unix socket"
 	},
 	{NULL}

--- a/miniupnpc/pymoduletest.py
+++ b/miniupnpc/pymoduletest.py
@@ -7,15 +7,21 @@
 # import the python miniupnpc module
 import miniupnpc
 import sys
+import argparse
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-m', '--multicastif')
+parser.add_argument('-p', '--minissdpdsocket')
+parser.add_argument('-d', '--discoverdelay', type=int, default=200)
 
 # create the object
-u = miniupnpc.UPnP()
+u = miniupnpc.UPnP(**vars(parser.parse_args()))
 print 'inital(default) values :'
 print ' discoverdelay', u.discoverdelay
 print ' lanaddr', u.lanaddr
 print ' multicastif', u.multicastif
 print ' minissdpdsocket', u.minissdpdsocket
-u.discoverdelay = 200;
 #u.minissdpdsocket = '../minissdpd/minissdpd.sock'
 # discovery process, it usualy takes several seconds (2 seconds or more)
 print 'Discovering... delay=%ums' % u.discoverdelay


### PR DESCRIPTION
Example: `pymoduletest.py -m br0` 

Full help:
```
$ pymoduletest.py -h
usage: pymoduletest.py [-h] [-m MULTICASTIF] [-p MINISSDPDSOCKET]
                       [-d DISCOVERDELAY]

optional arguments:
  -h, --help            show this help message and exit
  -m MULTICASTIF, --multicastif MULTICASTIF
  -p MINISSDPDSOCKET, --minissdpdsocket MINISSDPDSOCKET
  -d DISCOVERDELAY, --discoverdelay DISCOVERDELAY
```