### PR TITLE
Add #define for unix socket response buffer size

### DIFF
--- a/minissdpd/config.h
+++ b/minissdpd/config.h
@@ -19,6 +19,9 @@
 /* Maximum number of network interface we can listen on */
 #define MAX_IF_ADDR 8
 
+/* The size of unix socket response buffer */
+#define RESPONSE_BUFFER_SIZE (1024 * 4)
+
 /* Uncomment the following line in order to make minissdpd
  * listen on 1.2.3.4:1900 instead of *:1900
  * Note : it prevents broadcast packets to be received,

--- a/minissdpd/minissdpd.c
+++ b/minissdpd/minissdpd.c
@@ -726,7 +726,7 @@ void processRequest(struct reqelem * req)
 	const unsigned char * p;
 	int type;
 	struct device * d = devlist;
-	unsigned char rbuf[4096];
+	unsigned char rbuf[RESPONSE_BUFFER_SIZE];
 	unsigned char * rp = rbuf+1;
 	unsigned char nrep = 0;
 	time_t t;


### PR DESCRIPTION
On networks with many upnp devices, type 3 search truncates at 4K (Line 729: minissdpd/minissdpd.c).  This translates to about 32 devices.  Update config.h RESPONSE_BUFFER_SIZE as needed before make.  By default,  the buffer size remains the same so that memory profile is not altered.  In my use case, 32K bufffer size can yield 190 devices in IPv4.  We use 50K as our setting which should support all devices on a /24 network.