### PR TITLE
Minor Changes Proposed to Allow Easier Merge of Upstream to Tomato

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -265,8 +265,6 @@ case $OS_NAME in
 		OS_NAME=UPnP
 		OS_URL=http://tomatousb.org/
 		echo "" >> ${CONFIGFILE}
-		echo "#include <tomato_config.h>" >> ${CONFIGFILE}
-		echo "" >> ${CONFIGFILE}
 		echo "#ifdef LINUX26" >> ${CONFIGFILE}
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}
 		echo "#endif" >> ${CONFIGFILE}

--- a/miniupnpd/linux/getifstats.c
+++ b/miniupnpd/linux/getifstats.c
@@ -107,7 +107,7 @@ getifstats(const char * ifname, struct ifdata * data)
 		}
 		fclose(f);
 	} else {
-		syslog(LOG_WARNING, "cannot read %s file : %m", fname);
+		syslog(LOG_INFO, "cannot read %s file : %m", fname);
 	}
 #ifdef GET_WIRELESS_STATS
 	if(data->baudrate == BAUDRATE_DEFAULT) {

--- a/miniupnpd/upnphttp.c
+++ b/miniupnpd/upnphttp.c
@@ -901,7 +901,7 @@ Process_upnphttp(struct upnphttp * h)
 		}
 		else if(n==0)
 		{
-			syslog(LOG_WARNING, "HTTP Connection closed unexpectedly");
+			syslog(LOG_WARNING, "HTTP Connection from %s closed unexpectedly", inet_ntoa(h->clientaddr));
 			h->state = EToDelete;
 		}
 		else
@@ -971,7 +971,7 @@ Process_upnphttp(struct upnphttp * h)
 		}
 		else if(n==0)
 		{
-			syslog(LOG_WARNING, "HTTP Connection closed inexpectedly");
+			syslog(LOG_WARNING, "HTTP Connection from %s closed unexpectedly", inet_ntoa(h->clientaddr));
 			h->state = EToDelete;
 		}
 		else


### PR DESCRIPTION
The changes include removal of an unused Tomato specific include in genconfig.sh, reduction of severity of one message to reduce verbosity, and addition of client info to a log message.

If merged, these changes will allow Tomato developers to more easilly incorporate updates to miniupnpd into Tomato.

A separate PR will be create for a Tomato specific item in miniupnpd.c, as that one will be slightly larger (although still impact-less to generic miniupnpd).

