### PR TITLE
Make Tomato's OS_VERSION shorter to stop SendSSDPNotify log messages

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -73,7 +73,8 @@ fi
 # Tomato USB special case
 if [ -f ../shared/tomato_version ]; then
 	OS_NAME=Tomato
-	OS_VERSION="Tomato $(cat ../shared/tomato_version)"
+	TOMATO_VER=`cat ../shared/tomato_version | cut -d' ' -f2,3`
+	OS_VERSION="Tomato $TOMATO_VER"
 fi
 
 ${RM} ${CONFIGFILE}


### PR DESCRIPTION
As discussed in this thread:
http://www.linksysinfo.org/index.php?threads/tomato-shibbys-releases.33858/page-53#post-262636

It appears that the Tomato OS_VERSION has gotten long enough, that it's causing SSDP_PACKET_MAX_LEN being larger than 512 by a few characters.

This change reduces unnecessary "verbiage" at the end of the Tomato OS_VERSION string.

In short, what was previously (as example):
     Tomato 1.28.0000 MIPSR2-130 K26AC USB AIO-64K
 will become
     Tomato MIPSR2-130 K26AC