### PR TITLE
Moving to setuptools to enable wheel

### DIFF
--- a/miniupnpc/setup.py
+++ b/miniupnpc/setup.py
@@ -6,7 +6,7 @@
 # python script to build the miniupnpc module under unix
 #
 # replace libminiupnpc.a by libminiupnpc.so for shared library usage
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from distutils import sysconfig
 sysconfig.get_config_vars()["OPT"] = ''
 sysconfig.get_config_vars()["CFLAGS"] = ''


### PR DESCRIPTION
This move to setuptools allows to build (relatively) new binary wheel distribution and keep current source distribution (https://pypi.python.org/pypi/miniupnpc/1.9) as well.

The miniupnpc is done in native code. In many cases you just want to get compiled working binaries compatible with the platform without recompiling them. This is critical for ARM processors, since compile time there is much longer.

The choice of setuptools and bdist_wheel is inline with latest python packaging recommendations: https://packaging.python.org/en/latest/current.html.