### PR TITLE
Read USN from SSDP messages.

### DIFF
--- a/miniupnpc/listdevices.c
+++ b/miniupnpc/listdevices.c
@@ -87,7 +87,7 @@ int main(int argc, char * * argv)
 	}
 	if(devlist) {
 		for(dev = devlist; dev != NULL; dev = dev->pNext) {
-			printf("%-48s\t%s\n", dev->st, dev->descURL);
+			printf("%-100s\t%s\n", dev->usn, dev->descURL);
 		}
 		freeUPNPDevlist(devlist);
 	} else {

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -272,7 +272,8 @@ char * simpleUPnPcommand(int s, const char * url, const char * service,
 static void
 parseMSEARCHReply(const char * reply, int size,
                   const char * * location, int * locationsize,
-			      const char * * st, int * stsize)
+			      const char * * st, int * stsize,
+			      const char * * usn, int * usnsize)
 {
 	int a, b, i;
 	i = 0;
@@ -313,6 +314,11 @@ parseMSEARCHReply(const char * reply, int size,
 					{
 						*st = reply+b;
 						*stsize = i-b;
+					}
+					else if(0==strncasecmp(reply+a, "usn", 3))
+					{
+						*usn = reply+b;
+						*usnsize = i-b;
 					}
 					b = 0;
 				}
@@ -692,24 +698,28 @@ upnpDiscoverDevices(const char * const deviceTypes[],
 				int urlsize=0;
 				const char * st=NULL;
 				int stsize=0;
-				parseMSEARCHReply(bufr, n, &descURL, &urlsize, &st, &stsize);
-				if(st&&descURL) {
+				const char * usn=NULL;
+				int usnsize=0;
+				parseMSEARCHReply(bufr, n, &descURL, &urlsize, &st, &stsize, &usn, &usnsize);
+				if(st&&descURL&&usn) {
 #ifdef DEBUG
-					printf("M-SEARCH Reply:\n  ST: %.*s\n  Location: %.*s\n",
-					       stsize, st, urlsize, descURL);
+					printf("M-SEARCH Reply:\n  ST: %.*s\n  USN: %.*s\n  Location: %.*s\n",
+					       stsize, st, usnsize, usn, urlsize, descURL);
 #endif /* DEBUG */
 					for(tmp=devlist; tmp; tmp = tmp->pNext) {
 						if(memcmp(tmp->descURL, descURL, urlsize) == 0 &&
 						   tmp->descURL[urlsize] == '\0' &&
 						   memcmp(tmp->st, st, stsize) == 0 &&
-						   tmp->st[stsize] == '\0')
+						   tmp->st[stsize] == '\0' &&
+						   memcmp(tmp->usn, usn, usnsize) == 0 &&
+						   tmp->usn[usnsize] == '\0')
 							break;
 					}
 					/* at the exit of the loop above, tmp is null if
 					 * no duplicate device was found */
 					if(tmp)
 						continue;
-					tmp = (struct UPNPDev *)malloc(sizeof(struct UPNPDev)+urlsize+stsize);
+					tmp = (struct UPNPDev *)malloc(sizeof(struct UPNPDev)+urlsize+stsize+usnsize);
 					if(!tmp) {
 						/* memory allocation error */
 						if(error)
@@ -719,10 +729,13 @@ upnpDiscoverDevices(const char * const deviceTypes[],
 					tmp->pNext = devlist;
 					tmp->descURL = tmp->buffer;
 					tmp->st = tmp->buffer + 1 + urlsize;
+					tmp->usn = tmp->st + 1 + stsize;
 					memcpy(tmp->buffer, descURL, urlsize);
 					tmp->buffer[urlsize] = '\0';
-					memcpy(tmp->buffer + urlsize + 1, st, stsize);
+					memcpy(tmp->st, st, stsize);
 					tmp->buffer[urlsize+1+stsize] = '\0';
+					memcpy(tmp->usn, usn, usnsize);
+					tmp->buffer[urlsize+1+stsize+1+usnsize] = '\0';
 					tmp->scope_id = scope_id;
 					devlist = tmp;
 				}

--- a/miniupnpc/miniupnpc.h
+++ b/miniupnpc/miniupnpc.h
@@ -38,7 +38,8 @@ struct UPNPDev {
 	char * descURL;
 	char * st;
 	unsigned int scope_id;
-	char buffer[2];
+	char * usn;
+	char buffer[3];
 };
 
 /* upnpDiscover()


### PR DESCRIPTION
USN is mandatory header so nothing should break.
Yes, this breaks ABI of miniupnpc, but I think it's worth it (descURL is not guaranteed to be constant, and I need unique service identifiers)
Note that I've changed listdevices to print USN instead of ST - may be not what you want in this tool.