### PR TITLE
Allow using persistent socket connection in minissdpc

### DIFF
--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -137,6 +137,8 @@ connectToMiniSSDPD(const char * socketpath)
 		perror("setsockopt");
 	}
 #endif /* #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT */
+	if(!socketpath)
+		socketpath = "/var/run/minissdpd.sock";
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, socketpath, sizeof(addr.sun_path));
 	/* TODO : check if we need to handle the EINTR */

--- a/miniupnpc/minissdpc.h
+++ b/miniupnpc/minissdpc.h
@@ -13,7 +13,9 @@
 /* error codes : */
 #define MINISSDPC_SUCCESS (0)
 #define MINISSDPC_SOCKET_ERROR (-101)
+#define MINISSDPC_MEMORY_ERROR (-102)
 #define MINISSDPC_INVALID_INPUT (-103)
+#define MINISSDPC_INVALID_SERVER_REPLY (-104)
 
 #ifdef __cplusplus
 extern "C" {

--- a/miniupnpc/minissdpc.h
+++ b/miniupnpc/minissdpc.h
@@ -8,8 +8,35 @@
 #ifndef MINISSDPC_H_INCLUDED
 #define MINISSDPC_H_INCLUDED
 
-struct UPNPDev *
-getDevicesFromMiniSSDPD(const char * devtype, const char * socketpath);
+#include "miniupnpc_declspec.h"
+
+/* error codes : */
+#define MINISSDPC_SUCCESS (0)
+#define MINISSDPC_SOCKET_ERROR (-101)
+#define MINISSDPC_INVALID_INPUT (-103)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MINIUPNP_LIBSPEC struct UPNPDev *
+getDevicesFromMiniSSDPD(const char * devtype, const char * socketpath, int * error);
+
+MINIUPNP_LIBSPEC int
+connectToMiniSSDPD(const char * socketpath);
+
+MINIUPNP_LIBSPEC int
+disconnectFromMiniSSDPD(int fd);
+
+MINIUPNP_LIBSPEC int
+requestDevicesFromMiniSSDPD(int fd, const char * devtype);
+
+MINIUPNP_LIBSPEC struct UPNPDev *
+receiveDevicesFromMiniSSDPD(int fd, int * error);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -394,7 +394,7 @@ upnpDiscoverDevices(const char * const deviceTypes[],
 		struct UPNPDev * minissdpd_devlist;
 		int only_rootdevice = 1;
 		minissdpd_devlist = getDevicesFromMiniSSDPD(deviceTypes[deviceIndex],
-		                                            minissdpdsock);
+		                                            minissdpdsock, 0);
 		if(minissdpd_devlist) {
 #ifdef DEBUG
 			printf("returned by MiniSSDPD: %s\t%s\n",


### PR DESCRIPTION
This change is split into 3 patches to simplify review. If you don't like my naming choices I'll readily change them.

In my application I implement DLNA, and I use only SSDP part of MiniUPnP with different implementations of HTTP and SOAP. (There are a lot of library options for HTTP and SOAP, but much less for SSDP).

I'd like to have minssdpc as a generic SSDP client library which can either use MiniSSDPd or fallback to in-process SSDP request. If you have no objections, I'll move request and receive parts of upnpDiscoverDevices into minssdpc too.