### PR TITLE
miniupnpd: Bind to device

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -370,6 +370,13 @@ OpenAndConfHTTPSocket(unsigned short * port)
 	listenname_len =  sizeof(struct sockaddr_in);
 #endif
 
+#ifndef MULTIPLE_EXTERNAL_IP
+	if(setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE, int_if_name, strlen(int_if_name)) < 0)
+	{
+		syslog(LOG_WARNING, "setsockopt(udp, SO_BINDTODEVICE): %m");
+	}
+#endif
+
 #ifdef ENABLE_IPV6
 	if(bind(s,
 	        ipv6 ? (struct sockaddr *)&listenname6 : (struct sockaddr *)&listenname4,
@@ -1101,6 +1108,9 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				use_ext_ip_addr = ary_options[i].value;
 				break;
 			case UPNPLISTENING_IP:
+#ifndef MULTIPLE_EXTERNAL_IP
+				int_if_name = ary_options[i].value;
+#endif
 				lan_addr = (struct lan_addr_s *) malloc(sizeof(struct lan_addr_s));
 				if (lan_addr == NULL)
 				{

--- a/miniupnpd/upnpglobalvars.c
+++ b/miniupnpd/upnpglobalvars.c
@@ -14,6 +14,10 @@
 
 /* network interface for internet */
 const char * ext_if_name = 0;
+#ifndef MULTIPLE_EXTERNAL_IP
+/* network interface for LAN */
+const char * int_if_name = 0;
+#endif
 
 /* file to store leases */
 #ifdef ENABLE_LEASEFILE

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -15,6 +15,10 @@
 
 /* name of the network interface used to acces internet */
 extern const char * ext_if_name;
+#ifndef MULTIPLE_EXTERNAL_IP
+/* network interface for LAN */
+extern const char * int_if_name;
+#endif
 
 /* file to store all leases */
 #ifdef ENABLE_LEASEFILE


### PR DESCRIPTION
This is needed when you have two interfaces with the same IP address
(for example using tinc).

This is not supported when you have MULTIPLE_EXTERNAL_IP