### PR TITLE
String handling fixes

### DIFF
--- a/miniupnpc/minisoap.c
+++ b/miniupnpc/minisoap.c
@@ -105,6 +105,8 @@ int soapPostSubmit(int fd,
 					   "Pragma: no-cache\r\n"
 					   "\r\n",
 					   url, httpversion, host, portstr, bodysize, action);
+	if ((unsigned int)headerssize >= sizeof(headerbuf))
+		return 0;
 #ifdef DEBUG
 	/*printf("SOAP request : headersize=%d bodysize=%d\n",
 	       headerssize, bodysize);

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -685,6 +685,11 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 		             (linklocal ? "[" UPNP_MCAST_LL_ADDR "]" :  "[" UPNP_MCAST_SL_ADDR "]")
 		             : UPNP_MCAST_ADDR,
 		             deviceTypes[deviceIndex], mx);
+		if ((unsigned int)n >= sizeof(bufr))
+		{
+			closesocket(sudp);
+			return NULL;
+		}
 #ifdef DEBUG
 		/*printf("Sending %s", bufr);*/
 		printf("Sending M-SEARCH request to %s with ST: %s\n",

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -110,7 +110,8 @@ char * simpleUPnPcommand2(int s, const char * url, const char * service,
 	snprintf(soapact, sizeof(soapact), "%s#%s", service, action);
 	if(args==NULL)
 	{
-		/*soapbodylen = */snprintf(soapbody, sizeof(soapbody),
+		int soapbodylen;
+		soapbodylen = snprintf(soapbody, sizeof(soapbody),
 						"<?xml version=\"1.0\"?>\r\n"
 	    	              "<" SOAPPREFIX ":Envelope "
 						  "xmlns:" SOAPPREFIX "=\"http://schemas.xmlsoap.org/soap/envelope/\" "
@@ -120,6 +121,8 @@ char * simpleUPnPcommand2(int s, const char * url, const char * service,
 						  "</" SERVICEPREFIX ":%s>"
 						  "</" SOAPPREFIX ":Body></" SOAPPREFIX ":Envelope>"
 					 	  "\r\n", action, service, action);
+		if ((unsigned int)soapbodylen >= sizeof(soapbody))
+			return NULL;
 	}
 	else
 	{
@@ -134,6 +137,8 @@ char * simpleUPnPcommand2(int s, const char * url, const char * service,
 						"<" SOAPPREFIX ":Body>"
 						"<" SERVICEPREFIX ":%s xmlns:" SERVICEPREFIX "=\"%s\">",
 						action, service);
+		if ((unsigned int)soapbodylen >= sizeof(soapbody))
+			return NULL;
 		p = soapbody + soapbodylen;
 		while(args->elt)
 		{

--- a/miniupnpc/miniwget.c
+++ b/miniupnpc/miniwget.c
@@ -414,6 +414,11 @@ miniwget3(const char * host,
 
 				 "\r\n",
 			   path, httpversion, host, port);
+	if ((unsigned int)len >= sizeof(buf))
+	{
+		closesocket(s);
+		return NULL;
+	}
 	sent = 0;
 	/* sending the HTTP request */
 	while(sent < len)


### PR DESCRIPTION
I found these bugs during a security audit of miniupnpc in the context of TALOS-2015-0035 in Bitcoin Core, and tried to fix them.

Neither of these are remote vulnerabilities, as they are triggered by input from the application not from the network. However they lead to exposure of memory contents or stack overflows when used as part of a multi-pronged exploit.

- Check return value of snprintf: snprintf on Linux returns the number of characters that would have been written if there was enough space in the buffer. Return an error condition if space was not sufficient.

- Account exactly for bytes when building buffer in simpleUPnPcommand2. The margin of 100 is not guaranteed to always be enough. When long parameters are passed in, it was possible to overflow the buffer.
