### PR TITLE
report UPnP version 1.0 in XML descriptions to be consistent with IGD…

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -102,7 +102,7 @@ echo "" >> ${CONFIGFILE}
 cat >> ${CONFIGFILE} <<EOF
 /* UPnP version reported in XML descriptions
  * 1.0 / 1.1 / 2.0 depending on which UDA (UPnP Device Architecture) Version */
-#define UPNP_VERSION_MAJOR	2
+#define UPNP_VERSION_MAJOR	1
 #define UPNP_VERSION_MINOR	0
 #define UPNP_VERSION_MAJOR_STR	XSTR(UPNP_VERSION_MAJOR)
 #define UPNP_VERSION_MINOR_STR	XSTR(UPNP_VERSION_MINOR)


### PR DESCRIPTION
…v2 specs

In the XML examples in all [IGDv2-related spec documents](http://upnp.org/specs/gw), the specVersion fields consistently use major=1, minor=0. Moreover, the [IGDv2 spec itself](http://upnp.org/specs/gw/UPnP-gw-InternetGatewayDevice-v2-Device.pdf) specifically says "For UPnP Versions 1.0 and 1.1". This should fix issue #167.