### PR TITLE
return SID in renew response

### DIFF
--- a/miniupnpd/upnpevents.c
+++ b/miniupnpd/upnpevents.c
@@ -143,8 +143,8 @@ upnpevents_addSubscriber(const char * eventurl,
 }
 
 /* renew a subscription (update the timeout) */
-int
-renewSubscription(const char * sid, int sidlen, int timeout)
+const char *
+upnpevents_renewSubscription(const char * sid, int sidlen, int timeout)
 {
 	struct subscriber * sub;
 	for(sub = subscriberlist.lh_first; sub != NULL; sub = sub->entries.le_next) {
@@ -155,10 +155,10 @@ renewSubscription(const char * sid, int sidlen, int timeout)
 				continue;
 #endif
 			sub->timeout = (timeout ? time(NULL) + timeout : 0);
-			return 0;
+			return sub->uuid;
 		}
 	}
-	return -1;
+	return NULL;
 }
 
 int

--- a/miniupnpd/upnpevents.h
+++ b/miniupnpd/upnpevents.h
@@ -36,8 +36,8 @@ upnpevents_addSubscriber(const char * eventurl,
 int
 upnpevents_removeSubscriber(const char * sid, int sidlen);
 
-int
-renewSubscription(const char * sid, int sidlen, int timeout);
+const char *
+upnpevents_renewSubscription(const char * sid, int sidlen, int timeout);
 
 void upnpevents_selectfds(fd_set *readset, fd_set *writeset, int * max_fd);
 void upnpevents_processfds(fd_set *readset, fd_set *writeset);

--- a/miniupnpd/upnphttp.c
+++ b/miniupnpd/upnphttp.c
@@ -665,11 +665,13 @@ with HTTP error 412 Precondition Failed. */
 				BuildResp2_upnphttp(h, 400, "Incompatible header fields", 0, 0);
 			} else
 #endif
-			if(renewSubscription(h->req_buf + h->req_SIDOff, h->req_SIDLen,
-			                     h->req_Timeout) < 0) {
+			sid = upnpevents_renewSubscription(h->req_buf + h->req_SIDOff,
+			                                   h->req_SIDLen, h->req_Timeout);
+			if(!sid) {
 				BuildResp2_upnphttp(h, 412, "Precondition Failed", 0, 0);
 			} else {
-				h->respflags = FLAG_TIMEOUT;
+				h->respflags = FLAG_TIMEOUT | FLAG_SID;
+				h->res_SID = sid;
 				BuildResp_upnphttp(h, 0, 0);
 			}
 		}


### PR DESCRIPTION
Per the spec, renew responses should have the same format as subscription responses, and as such they should include the SID: field. Found this using the "Intel Device Validator for UPnP Technologies" tool.