### PR TITLE
advertise correct service and device versions when IGDv2 is enabled

### DIFF
--- a/miniupnpd/minissdp.c
+++ b/miniupnpd/minissdp.c
@@ -497,14 +497,6 @@ SendSSDPResponse(int s, const struct sockaddr * addr,
 	}
 }
 
-#ifndef IGD_V2
-#define IGD_VER 1
-#define WANIPC_VER 1
-#else
-#define IGD_VER 2
-#define WANIPC_VER 2
-#endif
-
 static struct {
 	const char * s;
 	const int version;
@@ -512,11 +504,22 @@ static struct {
 } const known_service_types[] =
 {
 	{"upnp:rootdevice", 0, uuidvalue_igd},
-	{"urn:schemas-upnp-org:device:InternetGatewayDevice:", IGD_VER, uuidvalue_igd},
+#ifdef IGD_V2
+	{"urn:schemas-upnp-org:device:InternetGatewayDevice:", 2, uuidvalue_igd},
+	{"urn:schemas-upnp-org:device:WANConnectionDevice:", 2, uuidvalue_wcd},
+	{"urn:schemas-upnp-org:device:WANDevice:", 2, uuidvalue_wan},
+	{"urn:schemas-upnp-org:service:WANIPConnection:", 2, uuidvalue_wcd},
+	{"urn:schemas-upnp-org:service:DeviceProtection:", 1, uuidvalue_igd},
+#ifdef ENABLE_6FC_SERVICE
+	{"urn:schemas-upnp-org:service:WANIPv6FirewallControl:", 1, uuidvalue_wcd},
+#endif
+#else
+	{"urn:schemas-upnp-org:device:InternetGatewayDevice:", 1, uuidvalue_igd},
 	{"urn:schemas-upnp-org:device:WANConnectionDevice:", 1, uuidvalue_wcd},
 	{"urn:schemas-upnp-org:device:WANDevice:", 1, uuidvalue_wan},
+	{"urn:schemas-upnp-org:service:WANIPConnection:", 1, uuidvalue_wcd},
+#endif
 	{"urn:schemas-upnp-org:service:WANCommonInterfaceConfig:", 1, uuidvalue_wan},
-	{"urn:schemas-upnp-org:service:WANIPConnection:", WANIPC_VER, uuidvalue_wcd},
 #ifndef UPNP_STRICT
 	/* We use WAN IP Connection, not PPP connection,
 	 * but buggy control points may try to use WanPPPConnection
@@ -525,9 +528,6 @@ static struct {
 #endif
 #ifdef ENABLE_L3F_SERVICE
 	{"urn:schemas-upnp-org:service:Layer3Forwarding:", 1, uuidvalue_igd},
-#endif
-#ifdef ENABLE_6FC_SERVICE
-	{"urn:schemas-upnp-org:service:WANIPv6FirewallControl:", 1, uuidvalue_wcd},
 #endif
 /* we might want to support urn:schemas-wifialliance-org:device:WFADevice:1
  * urn:schemas-wifialliance-org:device:WFADevice:1

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -1187,7 +1187,11 @@ GetDefaultConnectionService(struct upnphttp * h, const char * action, const char
 	static const char resp[] =
 		"<u:%sResponse "
 		"xmlns:u=\"%s\">"
+#ifdef IGD_V2
+		"<NewDefaultConnectionService>%s:WANConnectionDevice:2,"
+#else
 		"<NewDefaultConnectionService>%s:WANConnectionDevice:1,"
+#endif
 		SERVICE_ID_WANIPC "</NewDefaultConnectionService>"
 		"</u:%sResponse>";
 	/* example from UPnP_IGD_Layer3Forwarding 1.0.pdf :


### PR DESCRIPTION
The device and service notifications generated by miniupnpd use the IGDv1 versions of the various device and service descriptors even when compiling with IGDv2 enabled. They should always match the values in rootDesc.xml. This issue was flagged by the "Intel Device Validator for UPnP Technologies" tool.