### PR TITLE
fix action arguments for DeviceProtection service

### DIFF
--- a/miniupnpd/upnpdescgen.c
+++ b/miniupnpd/upnpdescgen.c
@@ -743,11 +743,32 @@ static const struct serviceDesc scpd6FC =
 
 #ifdef ENABLE_DP_SERVICE
 /* UPnP-gw-DeviceProtection-v1-Service.pdf */
+
+static const struct argument SendSetupMessageArgs[] =
+{
+	{1|0x80, 6},	/* ProtocolType */
+	{1|0x80, 5},	/* InMessage */
+	{2|0x80, 5},	/* OutMessage */
+	{0, 0}
+};
+
+static const struct argument GetSupportedProtocolsArgs[] =
+{
+	{2, 1},	/* ProtocolList */
+	{0, 0}
+};
+
+static const struct argument GetAssignedRolesArgs[] =
+{
+	{2, 6},	/* RoleList */
+	{0, 0}
+};
+
 static const struct action DPActions[] =
 {
-	{"SendSetupMessage", 0},
-	{"GetSupportedProtocols", 0},
-	{"GetAssignedRoles", 0},
+	{"SendSetupMessage", SendSetupMessageArgs},
+	{"GetSupportedProtocols", GetSupportedProtocolsArgs},
+	{"GetAssignedRoles", GetAssignedRolesArgs},
 	{0, 0}
 };
 

--- a/miniupnpd/upnpdescgen.c
+++ b/miniupnpd/upnpdescgen.c
@@ -115,7 +115,12 @@ static const char * magicargname[] = {
 	"RemotePort",
 	"InternalClient",
 	"InternalPort",
-	"IsWorking"
+	"IsWorking",
+	"ProtocolType",
+	"InMessage",
+	"OutMessage",
+	"ProtocolList",
+	"RoleList"
 };
 
 static const char xmlver[] =
@@ -746,21 +751,21 @@ static const struct serviceDesc scpd6FC =
 
 static const struct argument SendSetupMessageArgs[] =
 {
-	{1|0x80, 6},	/* ProtocolType */
-	{1|0x80, 5},	/* InMessage */
-	{2|0x80, 5},	/* OutMessage */
+	{1|0x80|(8<<2), 6},	/* ProtocolType */
+	{1|0x80|(9<<2), 5},	/* InMessage */
+	{2|0x80|(10<<2), 5},	/* OutMessage */
 	{0, 0}
 };
 
 static const struct argument GetSupportedProtocolsArgs[] =
 {
-	{2, 1},	/* ProtocolList */
+	{2|0x80|(11<<2), 1},	/* ProtocolList */
 	{0, 0}
 };
 
 static const struct argument GetAssignedRolesArgs[] =
 {
-	{2, 6},	/* RoleList */
+	{2|0x80|(12<<2), 6},	/* RoleList */
 	{0, 0}
 };
 

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -1985,7 +1985,7 @@ SendSetupMessage(struct upnphttp * h, const char * action, const char * ns)
 	static const char resp[] =
 		"<u:%sResponse "
 		"xmlns:u=\"%s\">"
-		"<NewOutMessage>%s</NewOutMessage>"
+		"<OutMessage>%s</OutMessage>"
 		"</u:%sResponse>";
 	char body[1024];
 	int bodylen;
@@ -2026,7 +2026,7 @@ GetSupportedProtocols(struct upnphttp * h, const char * action, const char * ns)
 	static const char resp[] =
 		"<u:%sResponse "
 		"xmlns:u=\"%s\">"
-		"<NewProtocolList>%s</NewProtocolList>"
+		"<ProtocolList>%s</ProtocolList>"
 		"</u:%sResponse>";
 	char body[1024];
 	int bodylen;
@@ -2052,7 +2052,7 @@ GetAssignedRoles(struct upnphttp * h, const char * action, const char * ns)
 	static const char resp[] =
 		"<u:%sResponse "
 		"xmlns:u=\"%s\">"
-		"<NewRoleList>%s</NewRoleList>"
+		"<RoleList>%s</RoleList>"
 		"</u:%sResponse>";
 	char body[1024];
 	int bodylen;


### PR DESCRIPTION
The definitions for the three actions for the DeviceProtection service are missing the parameters defined in [the spec](http://upnp.org/specs/gw/UPnP-gw-DeviceProtection-v1-Service.pdf). Also, the tags in the responses are incorrect (bogus "New" prefix).