### PR TITLE
Fix memory leak when realloc fails

### DIFF
--- a/miniupnpd/ipf/ipfrdr.c
+++ b/miniupnpd/ipf/ipfrdr.c
@@ -723,7 +723,7 @@ unsigned short *
 get_portmappings_in_range(unsigned short startport, unsigned short endport,
                           int proto, unsigned int * number)
 {
-	unsigned short * array;
+	unsigned short *array, *array2;
 	unsigned int capacity;
 	unsigned short eport;
 	ipfgeniter_t iter;
@@ -742,7 +742,7 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 		syslog(LOG_ERR, "get_portmappings_in_range() : calloc error");
 		return NULL;
 	}
-	
+
 	memset(&obj, 0, sizeof(obj));
 	obj.ipfo_rev = IPFILTER_VERSION;
 	obj.ipfo_ptr = &iter;
@@ -761,10 +761,10 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 			    "get_portmappings_in_range");
 			break;
 		}
-		
+
 		if (strcmp(ipn.in_tag.ipt_tag, group_name) != 0)
 			continue;
-		
+
 #if IPFILTER_VERSION >= 5000000
 		eport = ntohs(ipn.in_dpmin);
 		if( (eport == ntohs(ipn.in_dpmax))
@@ -781,13 +781,15 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 			{
 				/* need to increase the capacity of the array */
 				capacity += 128;
-				array = realloc(array, sizeof(unsigned short)*capacity);
-				if(!array)
+				array2 = realloc(array, sizeof(unsigned short)*capacity);
+				if(!array2)
 				{
 					syslog(LOG_ERR, "get_portmappings_in_range() : realloc(%lu) error", sizeof(unsigned short)*capacity);
 					*number = 0;
+					free(array);
 					return NULL;
 				}
+				array = array2;
 			}
 			array[*number] = eport;
 			(*number)++;

--- a/miniupnpd/ipfw/ipfwrdr.c
+++ b/miniupnpd/ipfw/ipfwrdr.c
@@ -430,7 +430,7 @@ get_portmappings_in_range(unsigned short startport,
                           int proto,
                           unsigned int * number)
 {
-	unsigned short * array = NULL;
+	unsigned short *array = NULL, *array2 = NULL;
 	unsigned int capacity = 128;
 	int i, count_rules, total_rules = 0;
 	struct ip_fw * rules = NULL;
@@ -459,12 +459,14 @@ get_portmappings_in_range(unsigned short startport,
 		    && eport <= endport) {
 			if(*number >= capacity) {
 				capacity += 128;
-				array = realloc(array, sizeof(unsigned short)*capacity);
-				if(!array) {
+				array2 = realloc(array, sizeof(unsigned short)*capacity);
+				if(!array2) {
 					syslog(LOG_ERR, "get_portmappings_in_range() : realloc(%lu) error", sizeof(unsigned short)*capacity);
 					*number = 0;
+					free(array);
 					goto error;
 				}
+				array = array2;
 			}
 			array[*number] = eport;
 			(*number)++;

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -154,7 +154,7 @@ tomato_save(const char *fname)
 			fclose(f);
 			rename(tmp, fname);
 		}
-		else 
+		else
 		{
 			close(t);
 		}
@@ -261,7 +261,7 @@ static void
 tomato_helper(void)
 {
 	struct stat st;
-	
+
 	if (stat("/etc/upnp/delete", &st) == 0)
 	{
 		tomato_delete();
@@ -1606,7 +1606,7 @@ init(int argc, char * * argv, struct runtime_vars * v)
 		syslog(LOG_ERR, "MiniUPnPd is already running. EXITING");
 		return 1;
 	}
-	
+
 #ifdef TOMATO
 	syslog(LOG_NOTICE, "version " MINIUPNPD_VERSION " started");
 #endif /* TOMATO */
@@ -1892,7 +1892,7 @@ main(int argc, char * * argv)
 			shttpl_v4 =  OpenAndConfHTTPSocket(&listen_port, 0);
 			if(shttpl_v4 < 0)
 			{
-				syslog(LOG_ERR, "Failed to open socket for HTTP on port %hu (IPv4). EXITING", v.port);
+				syslog(LOG_ERR, "Failed to open socket for HTTP on port %d (IPv4). EXITING", v.port);
 				return 1;
 			}
 		}
@@ -1916,7 +1916,7 @@ main(int argc, char * * argv)
 		shttpsl_v4 =  OpenAndConfHTTPSocket(&listen_port, 0);
 		if(shttpsl_v4 < 0)
 		{
-			syslog(LOG_ERR, "Failed to open socket for HTTPS on port %hu (IPv4). EXITING", v.https_port);
+			syslog(LOG_ERR, "Failed to open socket for HTTPS on port %d (IPv4). EXITING", v.https_port);
 			return 1;
 		}
 #endif /* V6SOCKETS_ARE_V6ONLY */

--- a/miniupnpd/netfilter/iptpinhole.c
+++ b/miniupnpd/netfilter/iptpinhole.c
@@ -297,7 +297,7 @@ delete_pinhole(unsigned short uid)
 			info = (const struct ip6t_tcp *)&match->data;
 			if((info->spts[0] == p->sport) && (info->dpts[0] == p->dport)) {
 				if(!ip6tc_delete_num_entry(miniupnpd_v6_filter_chain, index, h)) {
-					syslog(LOG_ERR, "ip6tc_delete_num_entry(%s,%d,...): %s",
+					syslog(LOG_ERR, "ip6tc_delete_num_entry(%s,%u,...): %s",
 					       miniupnpd_v6_filter_chain, index, ip6tc_strerror(errno));
 					goto error;
 				}

--- a/miniupnpd/pcplearndscp.c
+++ b/miniupnpd/pcplearndscp.c
@@ -228,7 +228,7 @@ read_learn_dscp_line(struct dscp_values *dscpvalues, char *p)
 				dscpvalues->dscp_value = 38;
 				break;
 			default:
-				fprintf(stderr, "Unknown AF value %u \n", af_value);
+				fprintf(stderr, "Unknown AF value %d \n", af_value);
 				goto exit_err_and_cleanup;
 			}
 			}

--- a/miniupnpd/portinuse.c
+++ b/miniupnpd/portinuse.c
@@ -79,7 +79,7 @@ port_in_use(const char *if_name,
 		ip_addr_str[0] = '\0';
 	}
 
-	syslog(LOG_DEBUG, "Check protocol %s for port %d on ext_if %s %s, %08X",
+	syslog(LOG_DEBUG, "Check protocol %s for port %u on ext_if %s %s, %08X",
 	    (proto==IPPROTO_TCP)?"tcp":"udp", eport, if_name,
 	    ip_addr_str, (unsigned)ip_addr.s_addr);
 
@@ -101,7 +101,7 @@ port_in_use(const char *if_name,
 			/* TODO add IPV6 support if enabled
 			 * Presently assumes IPV4 */
 #ifdef DEBUG
-			syslog(LOG_DEBUG, "port_in_use check port %d and address %s", tmp_port, eaddr);
+			syslog(LOG_DEBUG, "port_in_use check port %u and address %s", tmp_port, eaddr);
 #endif
 			if (tmp_port == eport) {
 				char tmp_addr[4];


### PR DESCRIPTION
Found by cppcheck. There are some warnings leftover, but it seems to be small that I don't bother touch it.