### PR TITLE
A few fixes for miniupnpd on DragonFly BSD

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -234,6 +234,9 @@ case $OS_NAME in
 		fi
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}
 		echo "#define PFRULE_INOUT_COUNTS" >> ${CONFIGFILE}
+		# net.inet6.ip6.v6only has been on by default for many years
+		# and this sysctl node has been removed
+		V6SOCKETS_ARE_V6ONLY=1
 		OS_URL=http://www.dragonflybsd.org/
 		;;
 	SunOS)

--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -233,6 +233,7 @@ case $OS_NAME in
 			FW=pf
 		fi
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}
+		echo "#define PFRULE_INOUT_COUNTS" >> ${CONFIGFILE}
 		OS_URL=http://www.dragonflybsd.org/
 		;;
 	SunOS)

--- a/miniupnpd/portinuse.c
+++ b/miniupnpd/portinuse.c
@@ -251,7 +251,7 @@ static struct nlist list[] = {
 			abort();
 		}
 		/* no support for IPv6 */
-		if ((inp->inp_vflag & INP_IPV6) != 0)
+		if (INP_ISIPV6(inp) != 0)
 			continue;
 		syslog(LOG_DEBUG, "%08lx:%hu %08lx:%hu <=> %hu %08lx:%hu",
 		       (u_long)inp->inp_laddr.s_addr, ntohs(inp->inp_lport),


### PR DESCRIPTION
- fix a few build issues
- when built with ENABLE_IPV6, miniupnpd didn't respond to requests made to its IPv4 addresses.