### PR TITLE
Set _GNU_SOURCE in asyncsendto.c

### DIFF
--- a/minissdpd/asyncsendto.c
+++ b/minissdpd/asyncsendto.c
@@ -5,6 +5,9 @@
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution */
 
+// for struct in6_pktinfo
+#define _GNU_SOURCE
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>


### PR DESCRIPTION
Add #define on _GNU_SOURCE at the very beginning of asyncsendto.c file
as this file uses in6_pktinfo which is protected by __USE_GNU in
libc/inet/netinet/in.h. Currently, this flag is set by the Makefile in
CFLAGS however CFLAGS could be overwritten by the build system.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>