### PR TITLE
Fix cmake file so project can be used as a subproject

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -66,8 +66,8 @@ if (CMAKE_COMPILER_IS_GNUC)
   endif (NOT CONFIGURED)
 endif ()
 
-configure_file (${CMAKE_SOURCE_DIR}/miniupnpcstrings.h.cmake ${CMAKE_BINARY_DIR}/miniupnpcstrings.h)
-include_directories (${CMAKE_BINARY_DIR})
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/miniupnpcstrings.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/miniupnpcstrings.h)
+include_directories (${CMAKE_CURRENT_BINARY_DIR})
 
 set (MINIUPNPC_SOURCES
   igd_desc_parse.c


### PR DESCRIPTION
I imported miniupnp as a git submodule in my cmake project and I was getting build errors. CMAKE_SOURCE_DIR always returns the path to the top-level cmake project, which is my project in this case (adding miniupnpc with add_subdirectory). CMAKE_CURRENT_SOURCE_DIR points to the intended directory instead. The same is true for CMAKE_BINARY_DIR/CMAKE_CURRENT_BINARY_DIR.