### PR TITLE
Add select CFLAGS to LDFLAGS

### DIFF
--- a/miniupnpc/Makefile
+++ b/miniupnpc/Makefile
@@ -70,6 +70,10 @@ ifeq (SunOS, $(OS))
   LDFLAGS=-lsocket -lnsl -lresolv
 endif
 
+# Flags that need to be passed to the linker so things "just work"
+CFLAGS_LD = -fopenmp -fsanitize=undefined -fsanitize=address -fsanitize=thread -fsanitize=memory
+LDFLAGS += $(strip $(filter $(CFLAGS_LD),$(CFLAGS)))
+
 # APIVERSION is used to build SONAME
 APIVERSION = 16
 


### PR DESCRIPTION
This will allow users to add OpenMP and Sanitizer flags, and make the flags available to the compiler driver during link. The compiler driver will then add the correct libraries, and avoid errors like:

```
$ CFLAGS="-fsanitize=address" make/bin/sh updateminiupnpcstrings.sh
Detected OS [Ubuntu] version [16.04]
MiniUPnPc version [2.0]
setting OS_STRING macro value to Ubuntu/16.04 in miniupnpcstrings.h.
setting MINIUPNPC_VERSION_STRING macro value to 2.0 in miniupnpcstrings.h.
cc -fPIC -fsanitize=address -Wall -W -Wstrict-prototypes -fno-common -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600   -c -o miniwget.o miniwget.c
...

cc -fPIC -fsanitize=address -Wall -W -Wstrict-prototypes -fno-common -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNPC_GET_SRC_ADDR -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600   -c -o upnpc.o upnpc.c
cc  -o upnpc-static upnpc.o libminiupnpc.a  
upnpc.o: In function `protofix':
upnpc.c:(.text+0x67): undefined reference to `__asan_report_load1'
upnpc.c:(.text+0xab): undefined reference to `__asan_report_load1'
upnpc.c:(.text+0x102): undefined reference to `__asan_report_load1'
upnpc.c:(.text+0x1ab): undefined reference to `__asan_report_load1'
upnpc.c:(.text+0x1ef): undefined reference to `__asan_report_load1'
upnpc.o:upnpc.c:(.text+0x246): more undefined references to `__asan_report_load1' follow
upnpc.o: In function `is_int':
upnpc.c:(.text+0x2da): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x312): undefined reference to `__asan_report_load1'
upnpc.c:(.text+0x35a): undefined reference to `__asan_report_load2'
upnpc.c:(.text+0x3a9): undefined reference to `__asan_report_load1'
upnpc.o: In function `DisplayInfos':
upnpc.c:(.text+0x3f0): undefined reference to `__asan_option_detect_stack_use_after_return'
upnpc.c:(.text+0x402): undefined reference to `__asan_stack_malloc_4'
upnpc.c:(.text+0x517): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x594): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x68c): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x87a): undefined reference to `__asan_report_load8'
upnpc.o: In function `GetConnectionStatus':
upnpc.c:(.text+0xa83): undefined reference to `__asan_report_load8'
upnpc.o:upnpc.c:(.text+0xac9): more undefined references to `__asan_report_load8' follow
upnpc.o: In function `ListRedirections':
upnpc.c:(.text+0xbd1): undefined reference to `__asan_option_detect_stack_use_after_return'
upnpc.c:(.text+0xbe3): undefined reference to `__asan_stack_malloc_4'
upnpc.c:(.text+0xd85): undefined reference to `__asan_report_load8'
upnpc.o: In function `NewListRedirections':
upnpc.c:(.text+0x101f): undefined reference to `__asan_option_detect_stack_use_after_return'
upnpc.c:(.text+0x1031): undefined reference to `__asan_stack_malloc_1'
upnpc.c:(.text+0x10e4): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x1176): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x11db): undefined reference to `__asan_report_load2'
upnpc.c:(.text+0x122b): undefined reference to `__asan_report_load2'
upnpc.c:(.text+0x12a3): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x132b): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x13b1): undefined reference to `__asan_report_load8'
upnpc.c:(.text+0x1416): undefined reference to `__asan_report_load2'
upnpc.c:(.text+0x1466): undefined reference to `__asan_report_load2'
upnpc.c:(.text+0x14de): undefined reference to `__asan_report_load8'
...
```