### PR TITLE
Please make the build reproducible

### DIFF
--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -60,6 +60,10 @@ CONFIGFILE_FINAL="config.h"
 CONFIGMACRO="CONFIG_H_INCLUDED"
 
 MINIUPNPD_DATE=`date +"%Y%m%d"`
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+	MINIUPNPD_DATE=`date --utc --date="@$SOURCE_DATE_EPOCH" +"%Y%m%d"`
+fi
+
 # Facility to syslog
 LOG_MINIUPNPD="LOG_DAEMON"
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed that
miniupnpd could not be built reproducibly due to embedded timestamps.

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>