### PR TITLE
Fix issue in CMakeLists.txt.

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -44,7 +44,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 endif ()
 
 # Set compiler specific build flags
-if (CMAKE_COMPILER_IS_GNUC)
+if (CMAKE_COMPILER_IS_GNUCC)
   # Set our own default flags at first run.
   if (NOT CONFIGURED)
 


### PR DESCRIPTION
CMAKE_COMPILER_IS_GNUC should be CMAKE_COMPILER_IS_GNUCC.
There is no variable named CMAKE_COMPILER_IS_GNUC, so the statements under if would never run.