### PR TITLE
Adding Tomato ifdef for netfilter chain to check

### DIFF
--- a/miniupnpd/portinuse.c
+++ b/miniupnpd/portinuse.c
@@ -56,7 +56,11 @@
 
 #if defined(USE_NETFILTER)
 /* Hardcoded for now.  Ideally would come from .conf file */
-char *chains_to_check[] = { "PREROUTING" , 0 };
+#	ifdef TOMATO
+		char *chains_to_check[] = { "WANPREROUTING" , 0 };
+#	else
+		char *chains_to_check[] = { "PREROUTING" , 0 };
+#	endif
 #endif
 
 int


### PR DESCRIPTION
To allow for "drop-in" upgrades of Miniupnp within Tomato firmware, submitting this change back upstream.
Original source:  https://bitbucket.org/kille72/tomato-arm-kille72/commits/b9d9e4b0ed761c6cdddd1227676b08bce2934481?at=shibby-arm

Have used ifdef for clarity of why the "new" entry is there (i.e. Tomato)