### PR TITLE
miniupnpc:py: build libminiupnpc.a

### DIFF
--- a/miniupnpc/miniupnpcmodule.c
+++ b/miniupnpc/miniupnpcmodule.c
@@ -307,7 +307,7 @@ UPnP_addportmapping(UPnPObject *self, PyObject *args)
 	const char * remoteHost;
 	const char * leaseDuration = "0";
 	int r;
-	if (!PyArg_ParseTuple(args, "HssHss", &ePort, &proto,
+	if (!PyArg_ParseTuple(args, "HssHzz", &ePort, &proto,
 	                                     &host, &iPort, &desc, &remoteHost))
         return NULL;
 Py_BEGIN_ALLOW_THREADS
@@ -349,7 +349,7 @@ UPnP_addanyportmapping(UPnPObject *self, PyObject *args)
 	const char * remoteHost;
 	const char * leaseDuration = "0";
 	int r;
-	if (!PyArg_ParseTuple(args, "HssHss", &ePort, &proto, &host, &iPort, &desc, &remoteHost))
+	if (!PyArg_ParseTuple(args, "HssHzz", &ePort, &proto, &host, &iPort, &desc, &remoteHost))
         return NULL;
 Py_BEGIN_ALLOW_THREADS
 	sprintf(extPort, "%hu", ePort);

--- a/miniupnpc/setup.py
+++ b/miniupnpc/setup.py
@@ -5,15 +5,18 @@
 # http://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/
 #
 # python script to build the miniupnpc module under unix
-#
-# replace libminiupnpc.a by libminiupnpc.so for shared library usage
-try:
-      from setuptools import setup, Extension
-except ImportError:
-      from distutils.core import setup, Extension
-from distutils import sysconfig
-sysconfig.get_config_vars()["OPT"] = ''
-sysconfig.get_config_vars()["CFLAGS"] = ''
+
+from setuptools import setup, Extension
+from setuptools.command import build_ext
+import subprocess
+
+EXT = ['libminiupnpc.a']
+
+class make_then_build_ext(build_ext.build_ext):
+      def run(self):
+            subprocess.check_call(['make'] + EXT)
+            build_ext.build_ext.run(self)
+
 setup(name="miniupnpc",
       version=open('VERSION').read().strip(),
       author='Thomas BERNARD',
@@ -21,8 +24,9 @@ setup(name="miniupnpc",
       license=open('LICENSE').read(),
       url='http://miniupnp.free.fr/',
       description='miniUPnP client',
+      cmdclass={'build_ext': make_then_build_ext},
       ext_modules=[
          Extension(name="miniupnpc", sources=["miniupnpcmodule.c"],
-                   extra_objects=["libminiupnpc.a"])
+                   extra_objects=EXT)
       ])
 


### PR DESCRIPTION
This allows to build the module directly via `pip`.