### PR TITLE
Add source IP and port to syslog for upnp_event_send() error.

### DIFF
--- a/miniupnpd/upnpevents.c
+++ b/miniupnpd/upnpevents.c
@@ -473,7 +473,8 @@ static void upnp_event_send(struct upnp_event_notify * obj)
 	i = send(obj->s, obj->buffer + obj->sent, obj->tosend - obj->sent, 0);
 	if(i<0) {
 		if(errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-			syslog(LOG_NOTICE, "%s: send(): %m", "upnp_event_send");
+			syslog(LOG_NOTICE, "%s: send(%s%s): %m", "upnp_event_send",
+			       obj->addrstr, obj->portstr);
 			obj->state = EError;
 			return;
 		} else {


### PR DESCRIPTION
Adds the IP and port of requesting host when a send error is logged to syslog so that it is possible to identify the application causing the problem.  Copied the syntax used for Connect() errors in same file.