### PR TITLE
Fixed incompatible types (from 'int *' to 'const char *') warning

### DIFF
--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -616,7 +616,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 
 	if(ipv6) {
 		int mcastHops = ttl;
-		if(setsockopt(sudp, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &mcastHops, sizeof(mcastHops)) < 0)
+		if(setsockopt(sudp, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char *)&mcastHops, sizeof(mcastHops)) < 0)
 		{
 			PRINT_SOCKET_ERROR("setsockopt(IPV6_MULTICAST_HOPS,...)");
 		}


### PR DESCRIPTION
VC++ 2015: miniupnpc\minissdpc.c(619): warning C4133: 'function': incompatible types - from 'int *' to 'const char *'