### PR TITLE
Update external-ip.sh, only output on success

### DIFF
--- a/miniupnpc/external-ip.sh
+++ b/miniupnpc/external-ip.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # $Id: external-ip.sh,v 1.1 2010/08/05 12:57:41 nanard Exp $
 # (c) 2010 Reuben Hawkins
-upnpc -s | grep ExternalIPAddress | sed 's/[^0-9\.]//g'
+upnpc -s | sed -n -e 's/^ExternalIPAddress = \([0-9.]*\)$/\1/p'


### PR DESCRIPTION
change sed pattern to only match when GetExternalIPAaddress succeeds and output nothing if it fails

```
$ upnpc -s | grep ExternalIPAddress | sed 's/[^0-9\.]//g'
.3
$ upnpc -s | grep ExternalIPAddress 
GetExternalIPAddress failed. (errorcode=-3)
$ upnpc -s | sed -n -e 's/^ExternalIPAddress = \([0-9.]*\)$/\1/p'
$
```