### PR TITLE
Allow runtime override of igd to v1 for people running binaries with v2 enabled

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1294,6 +1294,17 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPMINISSDPDSOCKET:
 				minissdpdsocketpath = ary_options[i].value;
 				break;
+#ifdef IGD_V2
+			case UPNPFORCEIGDDESCV1:
+				if (strcmp(ary_options[i].value, "yes")!=0 &&
+					strcmp(ary_options[i].value, "no")!=0 ) {
+					fprintf(stderr, "force_igd_desc_v1 can only be yes or no\n");
+				}
+				/* ary_options is processed by genRootDesc() to find
+				   this because there is apperently no way to pass
+				   options to the http server */
+				break;
+#endif
 			default:
 				fprintf(stderr, "Unknown option in file %s\n",
 				        optionsfile);

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -129,6 +129,10 @@ uuid=00000000-0000-0000-0000-000000000000
 #serial=12345678
 #model_number=1
 
+# If compiled with IGD_V2 defined, force reporting IGDv1 in rootDesc (default
+# is no)
+#force_igd_desc_v1=no
+
 # UPnP permission rules
 # (allow|deny) (external port range) IP/mask (internal port range)
 # A port range is <min port>-<max port> or <port> if there is only

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -83,6 +83,9 @@ static const struct {
 #ifdef ENABLE_LEASEFILE
 	{ UPNPLEASEFILE, "lease_file"},
 #endif
+#ifdef IGD_V2
+	{ UPNPFORCEIGDDESCV1, "force_igd_desc_v1"},
+#endif
 	{ UPNPMINISSDPDSOCKET, "minissdpdsocket"},
 	{ UPNPSECUREMODE, "secure_mode"}
 };

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -66,6 +66,9 @@ enum upnpconfigoptions {
 	UPNPLEASEFILE,			/* lease_file */
 #endif
 	UPNPMINISSDPDSOCKET,	/* minissdpdsocket */
+#ifdef IGD_V2
+	UPNPFORCEIGDDESCV1,
+#endif
 	UPNPENABLE				/* enable_upnp */
 };
 

--- a/miniupnpd/testupnpdescgen.c
+++ b/miniupnpd/testupnpdescgen.c
@@ -44,6 +44,11 @@ const char * ext_if_name = "eth0";
 
 int runtime_flags = 0;
 
+#ifdef IGD_V2
+struct option * ary_options = NULL;
+unsigned int num_options = 0;
+#endif
+
 int getifaddr(const char * ifname, char * buf, int len, struct in_addr * addr, struct in_addr * mask)
 {
 	UNUSED(ifname);


### PR DESCRIPTION
Towards miniupnp/miniupnp#277

Hopefully this allows people running distros that blindly enable v2 to override it at run time.

tested with windows 10 and windows 7 upnp clients