### PR TITLE
Windows 64-bit compatibility (Visual C++).

### DIFF
--- a/miniupnpc/connecthostport.h
+++ b/miniupnpc/connecthostport.h
@@ -8,11 +8,12 @@
 #ifndef CONNECTHOSTPORT_H_INCLUDED
 #define CONNECTHOSTPORT_H_INCLUDED
 
+#include "socketdef.h"
+
 /* connecthostport()
  * return a socket connected (TCP) to the host and port
- * or -1 in case of error */
-int connecthostport(const char * host, unsigned short port,
+ * or INVALID_SOCKET in case of error */
+SOCKET connecthostport(const char * host, unsigned short port,
                     unsigned int scope_id);
 
 #endif
-

--- a/miniupnpc/minisoap.c
+++ b/miniupnpc/minisoap.c
@@ -34,7 +34,7 @@
 /* httpWrite sends the headers and the body to the socket
  * and returns the number of bytes sent */
 static int
-httpWrite(int fd, const char * body, int bodysize,
+httpWrite(SOCKET fd, const char * body, int bodysize,
           const char * headers, int headerssize)
 {
 	int n = 0;
@@ -56,7 +56,7 @@ httpWrite(int fd, const char * body, int bodysize,
 	  PRINT_SOCKET_ERROR("send");
 	}
 	/* disable send on the socket */
-	/* draytek routers don't seem to like that... */
+	/* draytek routers dont seem to like that... */
 #if 0
 #ifdef _WIN32
 	if(shutdown(fd, SD_SEND)<0) {
@@ -71,7 +71,7 @@ httpWrite(int fd, const char * body, int bodysize,
 }
 
 /* self explanatory  */
-int soapPostSubmit(int fd,
+int soapPostSubmit(SOCKET fd,
                    const char * url,
 				   const char * host,
 				   unsigned short port,

--- a/miniupnpc/minisoap.h
+++ b/miniupnpc/minisoap.h
@@ -7,8 +7,10 @@
 #ifndef MINISOAP_H_INCLUDED
 #define MINISOAP_H_INCLUDED
 
+#include "socketdef.h"
+
 /*int httpWrite(int, const char *, int, const char *);*/
-int soapPostSubmit(int, const char *, const char *, unsigned short,
+int soapPostSubmit(SOCKET, const char *, const char *, unsigned short,
 		   const char *, const char *, const char *);
 
 #endif

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -20,7 +20,6 @@
 #include <ws2tcpip.h>
 #include <io.h>
 #include <iphlpapi.h>
-#include <winsock.h>
 #define snprintf _snprintf
 #if !defined(_MSC_VER)
 #include <stdint.h>
@@ -488,7 +487,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 	"\r\n";
 	int deviceIndex;
 	char bufr[1536];	/* reception and emission buffer */
-	int sudp;
+	SOCKET sudp;
 	int n;
 	struct sockaddr_storage sockudp_r;
 	unsigned int mx;
@@ -513,10 +512,11 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 
 #ifdef _WIN32
 	sudp = socket(ipv6 ? PF_INET6 : PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (ISINVALID(sudp))
 #else
 	sudp = socket(ipv6 ? PF_INET6 : PF_INET, SOCK_DGRAM, 0);
+	if (sudp < 0)
 #endif
-	if(sudp < 0)
 	{
 		if(error)
 			*error = MINISSDPC_SOCKET_ERROR;
@@ -566,18 +566,18 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			dwRetVal = GetIpAddrTable( pIPAddrTable, &dwSize, 0 );
 			if (dwRetVal == NO_ERROR) {
 #ifdef DEBUG
-				printf("\tNum Entries: %ld\n", pIPAddrTable->dwNumEntries);
+				printf("\tNum Entries: %lu\n", pIPAddrTable->dwNumEntries);
 #endif
 				for (i=0; i < (int) pIPAddrTable->dwNumEntries; i++) {
 #ifdef DEBUG
-					printf("\n\tInterface Index[%d]:\t%ld\n", i, pIPAddrTable->table[i].dwIndex);
+					printf("\n\tInterface Index[%d]:\t%lu\n", i, pIPAddrTable->table[i].dwIndex);
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwAddr;
 					printf("\tIP Address[%d]:     \t%s\n", i, inet_ntoa(IPAddr) );
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwMask;
 					printf("\tSubnet Mask[%d]:    \t%s\n", i, inet_ntoa(IPAddr) );
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwBCastAddr;
-					printf("\tBroadCast[%d]:      \t%s (%ld)\n", i, inet_ntoa(IPAddr), pIPAddrTable->table[i].dwBCastAddr);
-					printf("\tReassembly size[%d]:\t%ld\n", i, pIPAddrTable->table[i].dwReasmSize);
+					printf("\tBroadCast[%d]:      \t%s (%lu)\n", i, inet_ntoa(IPAddr), pIPAddrTable->table[i].dwBCastAddr);
+					printf("\tReassembly size[%d]:\t%lu\n", i, pIPAddrTable->table[i].dwReasmSize);
 					printf("\tType and State[%d]:", i);
 					printf("\n");
 #endif
@@ -597,7 +597,6 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 				}
 			}
 			free(pIPAddrTable);
-			pIPAddrTable = NULL;
 		}
 	}
 #endif	/* _WIN32 */
@@ -785,7 +784,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			break;
 		}
 		for(p = servinfo; p; p = p->ai_next) {
-			n = sendto(sudp, bufr, n, 0, p->ai_addr, p->ai_addrlen);
+			n = sendto(sudp, bufr, n, 0, p->ai_addr, (int)p->ai_addrlen);
 			if (n < 0) {
 #ifdef DEBUG
 				char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];

--- a/miniupnpc/minissdpc.h
+++ b/miniupnpc/minissdpc.h
@@ -8,7 +8,7 @@
 #ifndef MINISSDPC_H_INCLUDED
 #define MINISSDPC_H_INCLUDED
 
-#include "miniupnpc_declspec.h"
+//#include "miniupnpc_declspec.h"
 #include "upnpdev.h"
 
 /* error codes : */
@@ -32,13 +32,13 @@ MINIUPNP_LIBSPEC int
 connectToMiniSSDPD(const char * socketpath);
 
 MINIUPNP_LIBSPEC int
-disconnectFromMiniSSDPD(int fd);
+disconnectFromMiniSSDPD(int s);
 
 MINIUPNP_LIBSPEC int
-requestDevicesFromMiniSSDPD(int fd, const char * devtype);
+requestDevicesFromMiniSSDPD(int s, const char * devtype);
 
 MINIUPNP_LIBSPEC struct UPNPDev *
-receiveDevicesFromMiniSSDPD(int fd, int * error);
+receiveDevicesFromMiniSSDPD(int s, int * error);
 
 #endif /* !(defined(_WIN32) || defined(__amigaos__) || defined(__amigaos4__)) */
 

--- a/miniupnpc/miniwget.h
+++ b/miniupnpc/miniwget.h
@@ -9,12 +9,13 @@
 #define MINIWGET_H_INCLUDED
 
 #include "miniupnpc_declspec.h"
+#include "socketdef.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-MINIUPNP_LIBSPEC void * getHTTPResponse(int s, int * size, int * status_code);
+MINIUPNP_LIBSPEC void * getHTTPResponse(SOCKET s, int * size, int * status_code);
 
 MINIUPNP_LIBSPEC void * miniwget(const char *, int *, unsigned int, int *);
 

--- a/miniupnpc/minixml.h
+++ b/miniupnpc/minixml.h
@@ -10,7 +10,7 @@
  * */
 #ifndef MINIXML_H_INCLUDED
 #define MINIXML_H_INCLUDED
-#define IS_WHITE_SPACE(c) ((c==' ') || (c=='\t') || (c=='\r') || (c=='\n'))
+#define IS_WHITE_SPACE(c) ((c)==' ' || (c)=='\t' || (c)=='\r' || (c)=='\n')
 
 /* if a callback function pointer is set to NULL,
  * the function is not called */

--- a/miniupnpc/receivedata.c
+++ b/miniupnpc/receivedata.c
@@ -36,7 +36,7 @@
 #include "receivedata.h"
 
 int
-receivedata(int socket,
+receivedata(SOCKET socket,
             char * data, int length,
             int timeout, unsigned int * scope_id)
 {
@@ -102,4 +102,3 @@ receivedata(int socket,
 #endif	/* MINIUPNPC_GET_SRC_ADDR */
 	return n;
 }
-

--- a/miniupnpc/receivedata.h
+++ b/miniupnpc/receivedata.h
@@ -8,10 +8,12 @@
 #ifndef RECEIVEDATA_H_INCLUDED
 #define RECEIVEDATA_H_INCLUDED
 
+#include "socketdef.h"
+
 /* Reads data from the specified socket.
  * Returns the number of bytes read if successful, zero if no bytes were
  * read or if we timed out. Returns negative if there was an error. */
-int receivedata(int socket,
+int receivedata(SOCKET socket,
                 char * data, int length,
                 int timeout, unsigned int * scope_id);
 

--- a/miniupnpc/socketdef.h
+++ b/miniupnpc/socketdef.h
@@ -3,8 +3,12 @@
 #ifdef _MSC_VER
 #define ISINVALID(s) (INVALID_SOCKET==(s))
 #else
-typedef SOCKET int
-typedef SSIZE_T ssize_t
+typedef SOCKET int;
+typedef SSIZE_T ssize_t;
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET (-1)
+#endif
+#ifndef ISINVALID
 #define ISINVALID(s) (0>(s))
+#endif
 #endif

--- a/miniupnpc/socketdef.h
+++ b/miniupnpc/socketdef.h
@@ -3,8 +3,12 @@
 #ifdef _MSC_VER
 #define ISINVALID(s) (INVALID_SOCKET==(s))
 #else
-typedef SOCKET int;
-typedef SSIZE_T ssize_t;
+#ifndef
+#define SOCKET int
+#endif
+#ifndef
+#define SSIZE_T ssize_t
+#endif
 #ifndef INVALID_SOCKET
 #define INVALID_SOCKET (-1)
 #endif

--- a/miniupnpc/socketdef.h
+++ b/miniupnpc/socketdef.h
@@ -3,10 +3,10 @@
 #ifdef _MSC_VER
 #define ISINVALID(s) (INVALID_SOCKET==(s))
 #else
-#ifndef
+#ifndef SOCKET
 #define SOCKET int
 #endif
-#ifndef
+#ifndef SSIZE_T
 #define SSIZE_T ssize_t
 #endif
 #ifndef INVALID_SOCKET

--- a/miniupnpc/socketdef.h
+++ b/miniupnpc/socketdef.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifdef _MSC_VER
+#define ISINVALID(s) (INVALID_SOCKET==(s))
+#else
+typedef SOCKET int
+typedef SSIZE_T ssize_t
+#define INVALID_SOCKET (-1)
+#define ISINVALID(s) (0>(s))
+#endif

--- a/miniupnpc/upnpcommands.c
+++ b/miniupnpc/upnpcommands.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "upnpcommands.h"
 #include "miniupnpc.h"
-#include "portlistingparse.h"
+//#include "portlistingparse.h"
 
 static UNSIGNED_INTEGER
 my_atoui(const char * s)
@@ -32,11 +32,11 @@ UPNP_GetTotalBytesSent(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalBytesSent", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalBytesSent");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -56,11 +56,11 @@ UPNP_GetTotalBytesReceived(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalBytesReceived", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalBytesReceived");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -80,11 +80,11 @@ UPNP_GetTotalPacketsSent(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalPacketsSent", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalPacketsSent");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -104,11 +104,11 @@ UPNP_GetTotalPacketsReceived(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalPacketsReceived", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalPacketsReceived");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -141,7 +141,7 @@ UPNP_GetStatusInfo(const char * controlURL,
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	up = GetValueFromNameValueList(&pdata, "NewUptime");
 	p = GetValueFromNameValueList(&pdata, "NewConnectionStatus");
 	err = GetValueFromNameValueList(&pdata, "NewLastConnectionError");
@@ -201,7 +201,7 @@ UPNP_GetConnectionTypeInfo(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewConnectionType");
 	/*p = GetValueFromNameValueList(&pdata, "NewPossibleConnectionTypes");*/
 	/* PossibleConnectionTypes will have several values.... */
@@ -250,7 +250,7 @@ UPNP_GetLinkLayerMaxBitRates(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	/*down = GetValueFromNameValueList(&pdata, "NewDownstreamMaxBitRate");*/
 	/*up = GetValueFromNameValueList(&pdata, "NewUpstreamMaxBitRate");*/
 	down = GetValueFromNameValueList(&pdata, "NewLayer1DownstreamMaxBitRate");
@@ -314,7 +314,7 @@ UPNP_GetExternalIPAddress(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	/*printf("external ip = %s\n", GetValueFromNameValueList(&pdata, "NewExternalIPAddress") );*/
 	p = GetValueFromNameValueList(&pdata, "NewExternalIPAddress");
 	if(p) {
@@ -384,7 +384,7 @@ UPNP_AddPortMapping(const char * controlURL, const char * servicetype,
 	/*buffer[bufsize] = '\0';*/
 	/*puts(buffer);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		/*printf("AddPortMapping errorCode = '%s'\n", resVal); */
@@ -445,7 +445,7 @@ UPNP_AddAnyPortMapping(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -500,7 +500,7 @@ UPNP_DeletePortMapping(const char * controlURL, const char * servicetype,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -548,7 +548,7 @@ UPNP_DeletePortMappingRange(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -596,7 +596,7 @@ UPNP_GetGenericPortMappingEntry(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "NewRemoteHost");
 	if(p && rHost)
@@ -676,7 +676,7 @@ UPNP_GetPortMappingNumberOfEntries(const char * controlURL,
 	DisplayNameValueList(buffer, bufsize);
 #endif
  	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
  	p = GetValueFromNameValueList(&pdata, "NewPortMappingNumberOfEntries");
  	if(numEntries && p) {
@@ -738,7 +738,7 @@ UPNP_GetSpecificPortMappingEntry(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "NewInternalClient");
 	if(p) {
@@ -835,7 +835,7 @@ UPNP_GetListOfPortMappings(const char * controlURL,
 
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	/*p = GetValueFromNameValueList(&pdata, "NewPortListing");*/
 	/*if(p) {
@@ -897,7 +897,7 @@ UPNP_GetFirewallStatus(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	fe = GetValueFromNameValueList(&pdata, "FirewallEnabled");
 	ipa = GetValueFromNameValueList(&pdata, "InboundPinholeAllowed");
 	if(ipa && fe)
@@ -959,7 +959,7 @@ UPNP_GetOutboundPinholeTimeout(const char * controlURL, const char * servicetype
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1036,7 +1036,7 @@ UPNP_AddPinhole(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "UniqueID");
 	if(p)
 	{
@@ -1086,7 +1086,7 @@ UPNP_UpdatePinhole(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1128,7 +1128,7 @@ UPNP_DeletePinhole(const char * controlURL, const char * servicetype, const char
 		return UPNPCOMMAND_HTTP_ERROR;
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1170,7 +1170,7 @@ UPNP_CheckPinholeWorking(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "IsWorking");
 	if(p)
@@ -1217,7 +1217,7 @@ UPNP_GetPinholePackets(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "PinholePackets");
 	if(p)
@@ -1236,5 +1236,3 @@ UPNP_GetPinholePackets(const char * controlURL, const char * servicetype,
 	ClearNameValueList(&pdata);
 	return ret;
 }
-
-

--- a/miniupnpc/upnpcommands.h
+++ b/miniupnpc/upnpcommands.h
@@ -9,8 +9,8 @@
 
 #include "upnpreplyparse.h"
 #include "portlistingparse.h"
-#include "miniupnpc_declspec.h"
-#include "miniupnpctypes.h"
+//#include "miniupnpc_declspec.h"
+//#include "miniupnpctypes.h"
 
 /* MiniUPnPc return codes : */
 #define UPNPCOMMAND_SUCCESS (0)
@@ -208,7 +208,7 @@ UPNP_DeletePortMappingRange(const char * controlURL, const char * servicetype,
 MINIUPNP_LIBSPEC int
 UPNP_GetPortMappingNumberOfEntries(const char* controlURL,
                                    const char* servicetype,
-                                   unsigned int * num);
+                                   unsigned int * numEntries);
 
 /* UPNP_GetSpecificPortMappingEntry()
  *    retrieves an existing port mapping

--- a/miniupnpc/upnpdev.h
+++ b/miniupnpc/upnpdev.h
@@ -18,8 +18,8 @@ struct UPNPDev {
 	struct UPNPDev * pNext;
 	char * descURL;
 	char * st;
-	unsigned int scope_id;
 	char * usn;
+	unsigned int scope_id;
 	char buffer[3];
 };
 


### PR DESCRIPTION
1. In Windows 64-bit builds _SOCKET_ is a _UINT_PTR_ (_unisgned long long_), not  an _int_.  To keep most of the library code unchanged, a small header file **socketdef.h** was added.
Optionally this header could be included into project/make files.

Other changes
2. Removed unused header files (fine in Visual Studio, but to be verified in other compilers/OSes).
3. Removed zeroing of local pointers after _free()_ when the pointer is never used again, and that creates warnings in code analyzers.
4. Added some type casts to remove compiler warnings.
$. Fixed differences between parameter names in descriptions and definitions
6. Changed field order in structure UPNPDev (improves memory alignment)
7. Removed always _true_/_false_ condition checks, and checks for null pointer before caling _free()_.