### PR TITLE
Modernize and cleanup CMakeLists.txt

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -1,73 +1,56 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project (miniupnpc C)
+
 set (MINIUPNPC_VERSION 2.0)
 set (MINIUPNPC_API_VERSION 17)
 
-if (NOT CMAKE_BUILD_TYPE)
-  if (WIN32)
-    set (DEFAULT_BUILD_TYPE MinSizeRel)
-  else (WIN32)
-    set (DEFAULT_BUILD_TYPE RelWithDebInfo)
-  endif(WIN32)
-    set (CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} CACHE STRING
-        "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
-        FORCE)
-endif()
-
 option (UPNPC_BUILD_STATIC "Build static library" TRUE)
 option (UPNPC_BUILD_SHARED "Build shared library" TRUE)
-if (NOT WIN32)
-  option (UPNPC_BUILD_TESTS "Build test executables" TRUE)
-endif (NOT WIN32)
+option (UPNPC_BUILD_TESTS "Build test executables" TRUE)
+option (UPNPC_BUILD_SAMPLE "Build sample executables" TRUE)
 option (NO_GETADDRINFO "Define NO_GETADDRINFO" FALSE)
 
-mark_as_advanced (NO_GETADDRINFO)
+if (NOT UPNPC_BUILD_STATIC AND NOT UPNPC_BUILD_SHARED)
+    message (FATAL "Both shared and static libraries are disabled!")
+endif ()
+
+# Interface library for compile definitions, flags and option
+add_library(miniupnpc-private INTERFACE)
 
 if (NO_GETADDRINFO)
-  add_definitions (-DNO_GETADDRINFO)
-endif (NO_GETADDRINFO)
+  target_compile_definitions(miniupnpc-private INTERFACE NO_GETADDRINFO)
+endif ()
 
 if (NOT WIN32)
-  add_definitions (-DMINIUPNPC_SET_SOCKET_TIMEOUT)
-  add_definitions (-D_BSD_SOURCE -D_DEFAULT_SOURCE)
+  target_compile_definitions(miniupnpc-private INTERFACE 
+    MINIUPNPC_SET_SOCKET_TIMEOUT
+    _BSD_SOURCE _DEFAULT_SOURCE)
   if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     # add_definitions (-D_POSIX_C_SOURCE=200112L)
-    add_definitions (-D_XOPEN_SOURCE=600)
-  endif (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-else (NOT WIN32)
-  add_definitions (-D_WIN32_WINNT=0x0501) # XP or higher for getnameinfo and friends
-endif (NOT WIN32)
+    target_compile_definitions(miniupnpc-private INTERFACE _XOPEN_SOURCE=600)
+  endif ()
+else ()
+  target_compile_definitions(miniupnpc-private INTERFACE _WIN32_WINNT=0x0501) # XP or higher for getnameinfo and friends
+endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  add_definitions (-D_DARWIN_C_SOURCE)
+  target_compile_definitions(miniupnpc-private INTERFACE _DARWIN_C_SOURCE)
 endif ()
 
 # Set compiler specific build flags
-if (CMAKE_COMPILER_IS_GNUCC)
-  # Set our own default flags at first run.
-  if (NOT CONFIGURED)
-
-    if (NOT CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
-      set (_PIC -fPIC)
-    endif (CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
-
-    set (CMAKE_C_FLAGS "${_PIC} -Wall $ENV{CFLAGS}" # CMAKE_C_FLAGS gets appended to the other C flags
-        CACHE STRING "Flags used by the C compiler during normal builds." FORCE)
-    set (CMAKE_C_FLAGS_DEBUG "-g -DDDEBUG"
-        CACHE STRING "Flags used by the C compiler during debug builds." FORCE)
-    set (CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG"
-        CACHE STRING "Flags used by the C compiler during release builds." FORCE)
-    set (CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG"
-        CACHE STRING "Flags used by the C compiler during release builds." FORCE)
-    set (CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG"
-        CACHE STRING "Flags used by the C compiler during release builds." FORCE)
-
-  endif (NOT CONFIGURED)
+if (CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  target_compile_options(miniupnpc-private INTERFACE -Wall)
 endif ()
 
+# Suppress noise warnings
+if (MSVC)
+  target_compile_definitions(miniupnpc-private INTERFACE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/miniupnpcstrings.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/miniupnpcstrings.h)
-include_directories (${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(miniupnpc-private INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
 set (MINIUPNPC_SOURCES
   igd_desc_parse.c
@@ -83,89 +66,113 @@ set (MINIUPNPC_SOURCES
   connecthostport.c
   portlistingparse.c
   receivedata.c
+  connecthostport.h
+  igd_desc_parse.h
+  minisoap.h
+  minissdpc.h
+  miniupnpc.h
+  miniupnpctypes.h
+  miniwget.h
+  minixml.h
+  portlistingparse.h
+  receivedata.h
+  upnpcommands.h
+  upnpdev.h
+  upnperrors.h
+  upnpreplyparse.h
+  ${CMAKE_CURRENT_BINARY_DIR}/miniupnpcstrings.h
 )
 
 if (NOT WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
   set (MINIUPNPC_SOURCES ${MINIUPNPC_SOURCES} minissdpc.c)
-endif (NOT WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "AmigaOS")
+endif ()
 
 if (WIN32)
-  set_source_files_properties (${MINIUPNPC_SOURCES} PROPERTIES
-                                                    COMPILE_DEFINITIONS "MINIUPNP_STATICLIB;MINIUPNP_EXPORTS"
-  )
-endif (WIN32)
-
-if (WIN32)
-  find_library (WINSOCK2_LIBRARY NAMES ws2_32 WS2_32 Ws2_32)
-  find_library (IPHLPAPI_LIBRARY NAMES iphlpapi)
-  set (LDLIBS ${WINSOCK2_LIBRARY} ${IPHLPAPI_LIBRARY} ${LDLIBS})
+  target_link_libraries(miniupnpc-private INTERFACE ws2_32 iphlpapi)
 #elseif (CMAKE_SYSTEM_NAME STREQUAL "Solaris")
 #  find_library (SOCKET_LIBRARY NAMES socket)
 #  find_library (NSL_LIBRARY NAMES nsl)
 #  find_library (RESOLV_LIBRARY NAMES resolv)
 #  set (LDLIBS ${SOCKET_LIBRARY} ${NSL_LIBRARY} ${RESOLV_LIBRARY} ${LDLIBS})
-endif (WIN32)
+endif ()
 
-if (NOT UPNPC_BUILD_STATIC AND NOT UPNPC_BUILD_SHARED)
-    message (FATAL "Both shared and static libraries are disabled!")
-endif (NOT UPNPC_BUILD_STATIC AND NOT UPNPC_BUILD_SHARED)
 
 if (UPNPC_BUILD_STATIC)
   add_library (libminiupnpc-static STATIC ${MINIUPNPC_SOURCES})
   set_target_properties (libminiupnpc-static PROPERTIES OUTPUT_NAME "miniupnpc")
-  target_link_libraries (libminiupnpc-static ${LDLIBS})
-  set (UPNPC_INSTALL_TARGETS ${UPNPC_INSTALL_TARGETS} libminiupnpc-static)
-  set (UPNPC_LIBRARY_TARGET libminiupnpc-static)
-  add_executable (upnpc-static upnpc.c)
-  target_link_libraries (upnpc-static LINK_PRIVATE libminiupnpc-static)
-endif (UPNPC_BUILD_STATIC)
+  target_link_libraries (libminiupnpc-static PRIVATE miniupnpc-private)
+  target_include_directories(libminiupnpc-static INTERFACE ../${CMAKE_CURRENT_SOURCE_DIR})
+  target_compile_definitions(libminiupnpc-static PUBLIC MINIUPNP_STATICLIB)
+
+  install (TARGETS libminiupnpc-static
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib${LIB_SUFFIX}
+    ARCHIVE DESTINATION lib${LIB_SUFFIX})
+
+  if (UPNPC_BUILD_SAMPLE)
+    add_executable (upnpc-static upnpc.c)
+    target_link_libraries (upnpc-static PRIVATE libminiupnpc-static)
+    target_include_directories(upnpc-static PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  endif ()
+endif ()
 
 if (UPNPC_BUILD_SHARED)
   add_library (libminiupnpc-shared SHARED ${MINIUPNPC_SOURCES})
   set_target_properties (libminiupnpc-shared PROPERTIES OUTPUT_NAME "miniupnpc")
   set_target_properties (libminiupnpc-shared PROPERTIES VERSION ${MINIUPNPC_VERSION})
   set_target_properties (libminiupnpc-shared PROPERTIES SOVERSION ${MINIUPNPC_API_VERSION})
-  target_link_libraries (libminiupnpc-shared ${LDLIBS})
-  set (UPNPC_INSTALL_TARGETS ${UPNPC_INSTALL_TARGETS} libminiupnpc-shared)
-  set (UPNPC_LIBRARY_TARGET libminiupnpc-shared)
-  add_executable (upnpc-shared upnpc.c)
-  target_link_libraries (upnpc-shared LINK_PRIVATE libminiupnpc-shared)
-endif (UPNPC_BUILD_SHARED)
+  target_link_libraries (libminiupnpc-shared PRIVATE miniupnpc-private)
+  target_compile_definitions(libminiupnpc-shared PRIVATE MINIUPNP_EXPORTS)
+
+  target_include_directories(libminiupnpc-static INTERFACE ../${CMAKE_CURRENT_SOURCE_DIR})
+  if (WIN32)
+    target_link_libraries(libminiupnpc-shared INTERFACE ws2_32 iphlpapi)
+  endif()
+
+  install (TARGETS libminiupnpc-shared
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib${LIB_SUFFIX}
+    ARCHIVE DESTINATION lib${LIB_SUFFIX})
+
+  if (UPNPC_BUILD_SAMPLE)
+    add_executable (upnpc-shared upnpc.c)
+    target_link_libraries (upnpc-shared PRIVATE libminiupnpc-shared)
+    target_include_directories(upnpc-shared PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  endif ()
+endif ()
 
 if (UPNPC_BUILD_TESTS)
+  add_library(miniupnpc-tests INTERFACE)
+  target_link_libraries(miniupnpc-tests INTERFACE miniupnpc-private)
+  target_compile_definitions(miniupnpc-tests INTERFACE MINIUPNP_STATICLIB)
+
   add_executable (testminixml testminixml.c minixml.c igd_desc_parse.c)
-  target_link_libraries (testminixml ${LDLIBS})
+  target_link_libraries (testminixml PRIVATE miniupnpc-tests)
 
   add_executable (minixmlvalid minixmlvalid.c minixml.c)
-  target_link_libraries (minixmlvalid ${LDLIBS})
+  target_link_libraries (minixmlvalid PRIVATE miniupnpc-tests)
 
   add_executable (testupnpreplyparse testupnpreplyparse.c
                                      minixml.c upnpreplyparse.c)
-  target_link_libraries (testupnpreplyparse ${LDLIBS})
+  target_link_libraries (testupnpreplyparse PRIVATE miniupnpc-tests)
 
   add_executable (testigddescparse testigddescparse.c
                                    igd_desc_parse.c minixml.c miniupnpc.c miniwget.c minissdpc.c
                                    upnpcommands.c upnpreplyparse.c minisoap.c connecthostport.c
                                    portlistingparse.c receivedata.c
   )
-  target_link_libraries (testigddescparse ${LDLIBS})
+  target_link_libraries (testigddescparse PRIVATE miniupnpc-tests)
 
   add_executable (testminiwget testminiwget.c
                                miniwget.c miniupnpc.c minisoap.c upnpcommands.c minissdpc.c
                                upnpreplyparse.c minixml.c igd_desc_parse.c connecthostport.c
                                portlistingparse.c receivedata.c
   )
-  target_link_libraries (testminiwget ${LDLIBS})
+  target_link_libraries (testminiwget PRIVATE miniupnpc-tests)
 
 # set (UPNPC_INSTALL_TARGETS ${UPNPC_INSTALL_TARGETS} testminixml minixmlvalid testupnpreplyparse testigddescparse testminiwget)
-endif (UPNPC_BUILD_TESTS)
+endif ()
 
-
-install (TARGETS ${UPNPC_INSTALL_TARGETS}
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib${LIB_SUFFIX}
-  ARCHIVE DESTINATION lib${LIB_SUFFIX}
-)
 install (FILES
 	miniupnpc.h
   miniwget.h
@@ -179,7 +186,5 @@ install (FILES
   miniupnpc_declspec.h
   DESTINATION include/miniupnpc
 )
-
-set (CONFIGURED YES CACHE INTERNAL "")
 
 # vim: ts=2:sw=2


### PR DESCRIPTION
[Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1)

- Set the minimum required version for CMake to 3.5
- Added `UPNPC_BUILD_SAMPLE` option for building sample client application (upnpc.c)
- Added interface target library `miniupnpc-private` for common settings like compile definitions, flags and include directories. It helps to keep global scope clean.
  https://cmake.org/cmake/help/v3.11/manual/cmake-buildsystem.7.html#interface-libraries
- Replaced `-fPIC` compile option with `POSITION_INDEPENDENT_CODE` target property
  https://cmake.org/cmake/help/v3.11/prop_tgt/POSITION_INDEPENDENT_CODE.html#prop_tgt:POSITION_INDEPENDENT_CODE
- Set usage requirements for `libminiupnpc-*` targets for more convenient usage through `add_subdirectory()` (as cmake subproject)
  https://cmake.org/cmake/help/v3.11/manual/cmake-buildsystem.7.html#build-specification-and-usage-requirements
- Removed old and outdated code from CMakeLists.txt