### PR TITLE
A bunch of small changes

### DIFF
--- a/miniupnpc/connecthostport.c
+++ b/miniupnpc/connecthostport.c
@@ -183,7 +183,7 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #endif
 		return INVALID_SOCKET;
 	}
-	s = -1;
+	s = INVALID_SOCKET;
 	for(p = ai; p; p = p->ai_next)
 	{
 		s = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
@@ -208,7 +208,7 @@ SOCKET connecthostport(const char * host, unsigned short port,
 			PRINT_SOCKET_ERROR("setsockopt");
 		}
 #endif /* #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT */
-		n = connect(s, p->ai_addr, p->ai_addrlen);
+		n = connect(s, p->ai_addr, (int)p->ai_addrlen);
 #ifdef MINIUPNPC_IGNORE_EINTR
 		/* EINTR The system call was interrupted by a signal that was caught
 		 * EINPROGRESS The socket is nonblocking and the connection cannot
@@ -261,4 +261,3 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #endif /* #ifdef USE_GETHOSTBYNAME */
 	return s;
 }
-

--- a/miniupnpc/minisoap.c
+++ b/miniupnpc/minisoap.c
@@ -79,11 +79,10 @@ int soapPostSubmit(SOCKET fd,
 				   const char * body,
 				   const char * httpversion)
 {
-	int bodysize;
 	char headerbuf[512];
 	int headerssize;
 	char portstr[8];
-	bodysize = (int)strlen(body);
+	int bodysize = (int)strlen(body);
 	/* We are not using keep-alive HTTP connections.
 	 * HTTP/1.1 needs the header Connection: close to do that.
 	 * This is the default with HTTP/1.0

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -561,18 +561,18 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			dwRetVal = GetIpAddrTable( pIPAddrTable, &dwSize, 0 );
 			if (dwRetVal == NO_ERROR) {
 #ifdef DEBUG
-				printf("\tNum Entries: %ld\n", pIPAddrTable->dwNumEntries);
+				printf("\tNum Entries: %lu\n", pIPAddrTable->dwNumEntries);
 #endif
 				for (i=0; i < (int) pIPAddrTable->dwNumEntries; i++) {
 #ifdef DEBUG
-					printf("\n\tInterface Index[%d]:\t%ld\n", i, pIPAddrTable->table[i].dwIndex);
+					printf("\n\tInterface Index[%d]:\t%lu\n", i, pIPAddrTable->table[i].dwIndex);
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwAddr;
 					printf("\tIP Address[%d]:     \t%s\n", i, inet_ntoa(IPAddr) );
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwMask;
 					printf("\tSubnet Mask[%d]:    \t%s\n", i, inet_ntoa(IPAddr) );
 					IPAddr.S_un.S_addr = (u_long) pIPAddrTable->table[i].dwBCastAddr;
-					printf("\tBroadCast[%d]:      \t%s (%ld)\n", i, inet_ntoa(IPAddr), pIPAddrTable->table[i].dwBCastAddr);
-					printf("\tReassembly size[%d]:\t%ld\n", i, pIPAddrTable->table[i].dwReasmSize);
+					printf("\tBroadCast[%d]:      \t%s (%lu)\n", i, inet_ntoa(IPAddr), pIPAddrTable->table[i].dwBCastAddr);
+					printf("\tReassembly size[%d]:\t%lu\n", i, pIPAddrTable->table[i].dwReasmSize);
 					printf("\tType and State[%d]:", i);
 					printf("\n");
 #endif
@@ -592,7 +592,6 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 				}
 			}
 			free(pIPAddrTable);
-			pIPAddrTable = NULL;
 		}
 	}
 #endif	/* _WIN32 */
@@ -780,7 +779,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			break;
 		}
 		for(p = servinfo; p; p = p->ai_next) {
-			n = sendto(sudp, bufr, n, 0, p->ai_addr, p->ai_addrlen);
+			n = sendto(sudp, bufr, n, 0, p->ai_addr, (int)p->ai_addrlen);
 			if (n < 0) {
 #ifdef DEBUG
 				char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];

--- a/miniupnpc/minissdpc.h
+++ b/miniupnpc/minissdpc.h
@@ -32,13 +32,13 @@ MINIUPNP_LIBSPEC int
 connectToMiniSSDPD(const char * socketpath);
 
 MINIUPNP_LIBSPEC int
-disconnectFromMiniSSDPD(int fd);
+disconnectFromMiniSSDPD(int s);
 
 MINIUPNP_LIBSPEC int
-requestDevicesFromMiniSSDPD(int fd, const char * devtype);
+requestDevicesFromMiniSSDPD(int s, const char * devtype);
 
 MINIUPNP_LIBSPEC struct UPNPDev *
-receiveDevicesFromMiniSSDPD(int fd, int * error);
+receiveDevicesFromMiniSSDPD(int s, int * error);
 
 #endif /* !(defined(_WIN32) || defined(__amigaos__) || defined(__amigaos4__)) */
 

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -416,7 +416,7 @@ static char *
 build_absolute_url(const char * baseurl, const char * descURL,
                    const char * url, unsigned int scope_id)
 {
-	int l, n;
+	size_t l, n;
 	char * s;
 	const char * base;
 	char * p;
@@ -573,7 +573,7 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 	int ndev = 0;
 	int i;
 	int state = -1; /* state 1 : IGD connected. State 2 : IGD. State 3 : anything */
-	int n_igd = 0;
+//	int n_igd = 0;
 	char extIpAddr[16];
 	char myLanAddr[40];
 	int status_code = -1;
@@ -588,12 +588,12 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 	/* counting total number of devices in the list */
 	for(dev = devlist; dev; dev = dev->pNext)
 		ndev++;
-	if(ndev > 0)
-	{
-		desc = calloc(ndev, sizeof(struct xml_desc));
-		if(!desc)
-			return -1; /* memory allocation error */
-	}
+//	if(ndev > 0) always true
+//	{
+	desc = calloc(ndev, sizeof(struct xml_desc));
+	if(!desc)
+		return -1; /* memory allocation error */
+//	}
 	/* Step 1 : downloading descriptions and testing type */
 	for(dev = devlist, i = 0; dev; dev = dev->pNext, i++)
 	{
@@ -617,7 +617,7 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 			           "urn:schemas-upnp-org:service:WANCommonInterfaceConfig:"))
 			{
 				desc[i].is_igd = 1;
-				n_igd++;
+//				n_igd++;
 				if(lanaddr)
 					strncpy(lanaddr, myLanAddr, lanaddrlen);
 			}
@@ -685,14 +685,9 @@ UPNP_GetValidIGD(struct UPNPDev * devlist,
 	}
 	state = 0;
 free_and_return:
-	if(desc) {
-		for(i = 0; i < ndev; i++) {
-			if(desc[i].xml) {
-				free(desc[i].xml);
-			}
-		}
-		free(desc);
-	}
+	for(i = 0; i < ndev; i++)
+		free(desc[i].xml);
+	free(desc);
 	return state;
 }
 
@@ -717,7 +712,6 @@ UPNP_GetIGDFromUrl(const char * rootdescurl,
 		memset(urls, 0, sizeof(struct UPNPUrls));
 		parserootdesc(descXML, descXMLsize, data);
 		free(descXML);
-		descXML = NULL;
 		GetUPNPUrls(urls, data, rootdescurl, 0);
 		return 1;
 	} else {

--- a/miniupnpc/miniwget.c
+++ b/miniupnpc/miniwget.c
@@ -243,7 +243,7 @@ getHTTPResponse(SOCKET s, int * size, int * status_code)
 					/* reading chunk size */
 					if(chunksize_buf_index == 0) {
 						/* skipping any leading CR LF */
-						if(i<n && buf[i] == '\r') i++;
+						if(buf[i] == '\r') i++;
 						if(i<n && buf[i] == '\n') i++;
 					}
 					while(i<n && isxdigit(buf[i])
@@ -350,7 +350,7 @@ getHTTPResponse(SOCKET s, int * size, int * status_code)
 		}
 	}
 end_of_stream:
-	free(header_buf); header_buf = NULL;
+	free(header_buf);
 	*size = content_buf_used;
 	if(content_buf_used == 0)
 	{
@@ -371,7 +371,7 @@ miniwget3(const char * host,
           int * status_code)
 {
 	char buf[2048];
-    SOCKET s;
+	SOCKET s;
 	int n;
 	int len;
 	int sent;
@@ -559,7 +559,7 @@ parseURL(const char * url,
 #else
 			/* under windows, scope is numerical */
 			char tmp[8];
-			int l;
+			size_t l;
 			scope++;
 			/* "%25" is just '%' in URL encoding */
 			if(scope[0] == '2' && scope[1] == '5')
@@ -659,4 +659,3 @@ miniwget_getaddr(const char * url, int * size,
 #endif
 	return miniwget2(hostname, port, path, size, addr, addrlen, scope_id, status_code);
 }
-

--- a/miniupnpc/minixml.h
+++ b/miniupnpc/minixml.h
@@ -10,7 +10,7 @@
  * */
 #ifndef MINIXML_H_INCLUDED
 #define MINIXML_H_INCLUDED
-#define IS_WHITE_SPACE(c) ((c==' ') || (c=='\t') || (c=='\r') || (c=='\n'))
+#define IS_WHITE_SPACE(c) ((c)==' ' || (c)=='\t' || (c)=='\r' || (c)=='\n')
 
 /* if a callback function pointer is set to NULL,
  * the function is not called */

--- a/miniupnpc/upnpcommands.c
+++ b/miniupnpc/upnpcommands.c
@@ -33,11 +33,11 @@ UPNP_GetTotalBytesSent(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalBytesSent", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalBytesSent");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -57,11 +57,11 @@ UPNP_GetTotalBytesReceived(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalBytesReceived", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalBytesReceived");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -81,11 +81,11 @@ UPNP_GetTotalPacketsSent(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalPacketsSent", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalPacketsSent");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -105,11 +105,11 @@ UPNP_GetTotalPacketsReceived(const char * controlURL,
 	char * p;
 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                                "GetTotalPacketsReceived", 0, &bufsize))) {
-		return UPNPCOMMAND_HTTP_ERROR;
+		return (UNSIGNED_INTEGER)UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewTotalPacketsReceived");
 	r = my_atoui(p);
 	ClearNameValueList(&pdata);
@@ -142,7 +142,7 @@ UPNP_GetStatusInfo(const char * controlURL,
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
 	/*DisplayNameValueList(buffer, bufsize);*/
-	free(buffer); buffer = NULL;
+	free(buffer);
 	up = GetValueFromNameValueList(&pdata, "NewUptime");
 	p = GetValueFromNameValueList(&pdata, "NewConnectionStatus");
 	err = GetValueFromNameValueList(&pdata, "NewLastConnectionError");
@@ -202,7 +202,7 @@ UPNP_GetConnectionTypeInfo(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "NewConnectionType");
 	/*p = GetValueFromNameValueList(&pdata, "NewPossibleConnectionTypes");*/
 	/* PossibleConnectionTypes will have several values.... */
@@ -251,7 +251,7 @@ UPNP_GetLinkLayerMaxBitRates(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	/*down = GetValueFromNameValueList(&pdata, "NewDownstreamMaxBitRate");*/
 	/*up = GetValueFromNameValueList(&pdata, "NewUpstreamMaxBitRate");*/
 	down = GetValueFromNameValueList(&pdata, "NewLayer1DownstreamMaxBitRate");
@@ -315,7 +315,7 @@ UPNP_GetExternalIPAddress(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	/*printf("external ip = %s\n", GetValueFromNameValueList(&pdata, "NewExternalIPAddress") );*/
 	p = GetValueFromNameValueList(&pdata, "NewExternalIPAddress");
 	if(p) {
@@ -385,7 +385,7 @@ UPNP_AddPortMapping(const char * controlURL, const char * servicetype,
 	/*buffer[bufsize] = '\0';*/
 	/*puts(buffer);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		/*printf("AddPortMapping errorCode = '%s'\n", resVal); */
@@ -446,7 +446,7 @@ UPNP_AddAnyPortMapping(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -501,7 +501,7 @@ UPNP_DeletePortMapping(const char * controlURL, const char * servicetype,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -549,7 +549,7 @@ UPNP_DeletePortMappingRange(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal) {
 		ret = UPNPCOMMAND_UNKNOWN_ERROR;
@@ -597,7 +597,7 @@ UPNP_GetGenericPortMappingEntry(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "NewRemoteHost");
 	if(p && rHost)
@@ -677,7 +677,7 @@ UPNP_GetPortMappingNumberOfEntries(const char * controlURL,
 	DisplayNameValueList(buffer, bufsize);
 #endif
  	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
  	p = GetValueFromNameValueList(&pdata, "NewPortMappingNumberOfEntries");
  	if(numEntries && p) {
@@ -739,7 +739,7 @@ UPNP_GetSpecificPortMappingEntry(const char * controlURL,
 	}
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "NewInternalClient");
 	if(p) {
@@ -836,7 +836,7 @@ UPNP_GetListOfPortMappings(const char * controlURL,
 
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	/*p = GetValueFromNameValueList(&pdata, "NewPortListing");*/
 	/*if(p) {
@@ -898,7 +898,7 @@ UPNP_GetFirewallStatus(const char * controlURL,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	fe = GetValueFromNameValueList(&pdata, "FirewallEnabled");
 	ipa = GetValueFromNameValueList(&pdata, "InboundPinholeAllowed");
 	if(ipa && fe)
@@ -960,7 +960,7 @@ UPNP_GetOutboundPinholeTimeout(const char * controlURL, const char * servicetype
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1037,7 +1037,7 @@ UPNP_AddPinhole(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	p = GetValueFromNameValueList(&pdata, "UniqueID");
 	if(p)
 	{
@@ -1087,7 +1087,7 @@ UPNP_UpdatePinhole(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1129,7 +1129,7 @@ UPNP_DeletePinhole(const char * controlURL, const char * servicetype, const char
 		return UPNPCOMMAND_HTTP_ERROR;
 	/*DisplayNameValueList(buffer, bufsize);*/
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 	resVal = GetValueFromNameValueList(&pdata, "errorCode");
 	if(resVal)
 	{
@@ -1171,7 +1171,7 @@ UPNP_CheckPinholeWorking(const char * controlURL, const char * servicetype,
 		return UPNPCOMMAND_HTTP_ERROR;
 	}
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "IsWorking");
 	if(p)
@@ -1218,7 +1218,7 @@ UPNP_GetPinholePackets(const char * controlURL, const char * servicetype,
 	if(!buffer)
 		return UPNPCOMMAND_HTTP_ERROR;
 	ParseNameValue(buffer, bufsize, &pdata);
-	free(buffer); buffer = NULL;
+	free(buffer);
 
 	p = GetValueFromNameValueList(&pdata, "PinholePackets");
 	if(p)
@@ -1237,5 +1237,3 @@ UPNP_GetPinholePackets(const char * controlURL, const char * servicetype,
 	ClearNameValueList(&pdata);
 	return ret;
 }
-
-

--- a/miniupnpc/upnpcommands.h
+++ b/miniupnpc/upnpcommands.h
@@ -206,9 +206,9 @@ UPNP_DeletePortMappingRange(const char * controlURL, const char * servicetype,
 /* UPNP_GetPortMappingNumberOfEntries()
  * not supported by all routers */
 MINIUPNP_LIBSPEC int
-UPNP_GetPortMappingNumberOfEntries(const char* controlURL,
-                                   const char* servicetype,
-                                   unsigned int * num);
+UPNP_GetPortMappingNumberOfEntries(const char * controlURL,
+                                   const char * servicetype,
+                                   unsigned int * numEntries);
 
 /* UPNP_GetSpecificPortMappingEntry()
  *    retrieves an existing port mapping


### PR DESCRIPTION
That is what was left after merging changes for 64-bit Windows (you did a good job then).
This PR is supposed to decrease the number of warnings and slightly improve code style.

General considerations.

- Assignments of `NULL` to local variable after `free()` were disliked by static analysers.
The reason was: assigned value was never used.
Also compilers might optimize it away.
Therefore these assignment add very little to code safety, and could be dropped.
If you still would like to keep it, a simple macro might be used to eliminate these assignments in Release configurations.
- Use of the same parameter names in function declaration and definition should improve coding style.
- Enforced type consistency eliminates warnings (and prevents errors).

Additional comments.

`connecthostport.c`
Missed replacement: `-1` should have been `INVALID_SOCKET`.
`ai_addrlen` field is declared as `size_t` in MS VC, but parameter is `int` (truncation warning fix).

`minisoap.c`
Declaration and initialization in one line.

`minissdpc.c`
Prefix `dw` stands for `DWORD`, which is defined as `unsigned long`; and the correct format should be `%lu`, not `%ld`

`minissdpc.h`
Parameter names changed to match function's definitions.

`miniupnpc.c`
`strlen()` returns value of `size_t` type in MS VC. Hence the change from `int l, n;` to `size_t`
In `UPNP_GetValidIGD` checks were removed because some conditions should be always true.
Quick explanation:
`devlist` is not empty (line 581), therefore `ndev` is at least 1 in line 591
`desc` cannot be `NULL` after lines 594-595

`miniwget.c`
The first `i<n` condition was already verified in the loop header.
Change `int l;` to `size_t ;l` because of pointer arithmetics and sizeof.

`minixml.h`
Parentheses around macros and its parameters as a standard safety measure (static analysis).

upnpcommands.c
The constant `UPNPCOMMAND_HTTP_ERROR` is defined as signed, but it had to be used both as signed and unsigned (type mismatch warning fix).
