### PR TITLE
miniupnpc: Add information about iptables settings into README

### DIFF
--- a/miniupnpc/README
+++ b/miniupnpc/README
@@ -61,3 +61,30 @@ https://miniupnp.tuxfamily.org/forum/
 
 Bugs should be reported on github :
 https://github.com/miniupnp/miniupnp/issues
+
+* Linux firewall configuration for UPnP clients *
+
+Due to how UPnP protocol is designed, unicast responses to UPnP multicast client
+requests are not tracked by Linux netfilter. And therefore netfilter executes
+default action for them (which is in most cases DROP response packet).
+
+To workaround this limitation, custom ipset hash table can be used. It is
+supported since Linux kernel >= 2.6.39.
+
+Rules for IPv4:
+$ ipset create upnp hash:ip,port timeout 3
+$ iptables -A OUTPUT -d 239.255.255.250/32 -p udp -m udp --dport 1900 -j SET --add-set upnp src,src --exist
+$ iptables -A INPUT -p udp -m set --match-set upnp dst,dst -j ACCEPT
+$ iptables -A INPUT -d 239.255.255.250/32 -p udp -m udp --dport 1900 -j ACCEPT
+
+Rules for IPv6:
+$ ipset create upnp6 hash:ip,port timeout 3 family inet6
+$ ip6tables -A OUTPUT -d ff02::c/128 -p udp -m udp --dport 1900 -j SET --add-set upnp6 src,src --exist
+$ ip6tables -A OUTPUT -d ff05::c/128 -p udp -m udp --dport 1900 -j SET --add-set upnp6 src,src --exist
+$ ip6tables -A INPUT -p udp -m set --match-set upnp6 dst,dst -j ACCEPT
+$ ip6tables -A INPUT -d ff02::c/128 -p udp -m udp --dport 1900 -j ACCEPT
+$ ip6tables -A INPUT -d ff05::c/128 -p udp -m udp --dport 1900 -j ACCEPT
+
+Detailed description is available on:
+https://serverfault.com/a/911286
+https://unix.stackexchange.com/a/444804


### PR DESCRIPTION
Configuring iptables firewall for UPnP clients to not be too relax is not easy. This is because netfilter's conntrack module cannot track unicast UDP responses for UDP packets sent to multicast address. Most users either turn firewall off or accept any incoming UDP packets to have UPnP clients working.

But with introduction of ipset into Linux kernel >= 2.6.39 it is possible to have iptables set to fully restrictive mode (-P DROP) and allow UPnP clients working.

I think that it can be useful for miniupnp users, therefore I'm creating this pull request with iptables match rules for miniupnp project. Feel free to move it or drop if you think it is not useful at all.

Detailed description is available on:
https://serverfault.com/a/911286
https://unix.stackexchange.com/a/444804