### PR TITLE
Update renamed file in MSVC Project

### DIFF
--- a/miniupnpc/msvc/miniupnpc.vcxproj
+++ b/miniupnpc/msvc/miniupnpc.vcxproj
@@ -166,13 +166,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\connecthostport.h" />
-    <ClInclude Include="..\declspec.h" />
     <ClInclude Include="..\igd_desc_parse.h" />
     <ClInclude Include="..\minisoap.h" />
     <ClInclude Include="..\minissdpc.h" />
     <ClInclude Include="..\miniupnpc.h" />
     <ClInclude Include="..\miniupnpcstrings.h" />
     <ClInclude Include="..\miniupnpctypes.h" />
+    <ClInclude Include="..\miniupnpc_declspec.h" />
     <ClInclude Include="..\miniwget.h" />
     <ClInclude Include="..\minixml.h" />
     <ClInclude Include="..\portlistingparse.h" />

--- a/miniupnpc/msvc/miniupnpc.vcxproj.filters
+++ b/miniupnpc/msvc/miniupnpc.vcxproj.filters
@@ -62,9 +62,6 @@
     <ClInclude Include="..\connecthostport.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
-    <ClInclude Include="..\declspec.h">
-      <Filter>Fichiers d%27en-tête</Filter>
-    </ClInclude>
     <ClInclude Include="..\igd_desc_parse.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
@@ -105,6 +102,9 @@
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
     <ClInclude Include="..\upnpreplyparse.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="..\miniupnpc_declspec.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
declspec.h was renamed to miniupnpc_declspec.h but the MSVC file reference was not updated.

Thanks,
Brett