### PR TITLE
Ensure SSDP reply headers are not partial matches

### DIFF
--- a/miniupnpc-async/miniupnpc-async.c
+++ b/miniupnpc-async/miniupnpc-async.c
@@ -102,10 +102,10 @@ parse_msearch_reply(const char * reply, int size,
 			if(b!=0) {
 				/* skip the colon and white spaces */
 				do { b++; } while(reply[b]==' ' && b<size);
-				if(0==strncasecmp(reply+a, "location", 8)) {
+				if(0==strncasecmp(reply+a, "location:", 9)) {
 					*location = reply+b;
 					*locationsize = i-b;
-				} else if(0==strncasecmp(reply+a, "st", 2)) {
+				} else if(0==strncasecmp(reply+a, "st:", 3)) {
 					*st = reply+b;
 					*stsize = i-b;
 				}

--- a/miniupnpc-async/parsessdpreply.c
+++ b/miniupnpc-async/parsessdpreply.c
@@ -57,12 +57,12 @@ parseMSEARCHReply(const char * reply, int size,
 					}
 					putchar('\n');*/
 					do { b++; } while(reply[b]==' ');
-					if(0==strncasecmp(reply+a, "location", 8))
+					if(0==strncasecmp(reply+a, "location:", 9))
 					{
 						*location = reply+b;
 						*locationsize = i-b;
 					}
-					else if(0==strncasecmp(reply+a, "st", 2))
+					else if(0==strncasecmp(reply+a, "st:", 3))
 					{
 						*st = reply+b;
 						*stsize = i-b;

--- a/miniupnpc-libevent/miniupnpc-libevent.c
+++ b/miniupnpc-libevent/miniupnpc-libevent.c
@@ -123,10 +123,10 @@ parse_msearch_reply(const char * reply, int size,
 			if(b!=0) {
 				/* skip the colon and white spaces */
 				do { b++; } while(reply[b]==' ' && b<i);
-				if(0==strncasecmp(reply+a, "location", 8)) {
+				if(0==strncasecmp(reply+a, "location:", 9)) {
 					*location = reply+b;
 					*locationsize = i-b;
-				} else if(0==strncasecmp(reply+a, "st", 2)) {
+				} else if(0==strncasecmp(reply+a, "st:", 3)) {
 					*st = reply+b;
 					*stsize = i-b;
 				}

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -418,17 +418,17 @@ parseMSEARCHReply(const char * reply, int size,
 					putchar('\n');*/
 					/* skip the colon and white spaces */
 					do { b++; } while(reply[b]==' ');
-					if(0==strncasecmp(reply+a, "location", 8))
+					if(0==strncasecmp(reply+a, "location:", 9))
 					{
 						*location = reply+b;
 						*locationsize = i-b;
 					}
-					else if(0==strncasecmp(reply+a, "st", 2))
+					else if(0==strncasecmp(reply+a, "st:", 3))
 					{
 						*st = reply+b;
 						*stsize = i-b;
 					}
-					else if(0==strncasecmp(reply+a, "usn", 3))
+					else if(0==strncasecmp(reply+a, "usn:", 4))
 					{
 						*usn = reply+b;
 						*usnsize = i-b;


### PR DESCRIPTION
I stumbled upon this when reading through the SSDP reply parsing code. I don't know if any real world devices send SSDP reply headers that start with `st`, `location`, or `usn` without being an exact match, but it seems good to handle that possibility correctly nonetheless.