### PR TITLE
miniupnpd: add secure compilation flags for Linux

### DIFF
--- a/miniupnpd/Makefile.linux
+++ b/miniupnpd/Makefile.linux
@@ -25,11 +25,14 @@
 CFLAGS ?= -Os
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -fno-common
+CFLAGS += -fstack-protector -fPIE
+CFLAGS += -D_FORTIFY_SOURCE=2
 CPPFLAGS += -D_GNU_SOURCE
 CFLAGS += -Wall
 CFLAGS += -Wextra -Wstrict-prototypes -Wdeclaration-after-statement
 #CFLAGS += -Wno-missing-field-initializers
 #CFLAGS += -ansi	# iptables headers does use typeof which is a gcc extension
+LDFLAGS += -Wl,-z,now -Wl,-z,relro -pie
 CC ?= gcc
 RM = rm -f
 INSTALL = install


### PR DESCRIPTION
Add basic security compilation flags for miniupnpd Linux compilation, to mitigate memory corruption and other attacks
This is useful when using old compilers, cross-compilers or even just non-x86 compilers, as those are not configured to add these flags by default

I believe the same flags should work as-is for the BSD makefile as well, but I haven't tested it