### PR TITLE
Fix connect() socket error trace on Windows

### DIFF
--- a/miniupnpc/connecthostport.c
+++ b/miniupnpc/connecthostport.c
@@ -193,6 +193,8 @@ SOCKET connecthostport(const char * host, unsigned short port,
 	s = INVALID_SOCKET;
 	for(p = ai; p; p = p->ai_next)
 	{
+		if(!ISINVALID(s))
+			closesocket(s);
 		s = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 		if(ISINVALID(s))
 			continue;
@@ -260,7 +262,6 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #endif /* #ifdef MINIUPNPC_IGNORE_EINTR */
 		if(n < 0)
 		{
-			closesocket(s);
 			continue;
 		}
 		else
@@ -277,6 +278,7 @@ SOCKET connecthostport(const char * host, unsigned short port,
 	if(n < 0)
 	{
 		PRINT_SOCKET_ERROR("connect");
+		closesocket(s);
 		return INVALID_SOCKET;
 	}
 #endif /* #ifdef USE_GETHOSTBYNAME */


### PR DESCRIPTION
Calling `closesocket()` will result in Winsock internally calling `WSASetLastError(0)`, which wipes out the original error from the `connect()` call that we're trying to print with `PRINT_SOCKET_ERROR("connect")`. 

This results in stderr output like the following when connection errors occur while searching for devices:
```
Socket error: connect, 0
Socket error: connect, 0
Socket error: connect, 0
```

With some slight changes to the loop, we can avoid this situation and get the proper error codes:
```
Socket error: connect, 10060
Socket error: connect, 10060
Socket error: connect, 10060
```

