### PR TITLE
Fixing the Upnpc delivery process for windows targets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
-version: '2.1.{build}'
+environment:
+  APP_VERSION: '2.1'
+
+
+version: '$(APP_VERSION).{build}'
 
 image: Visual Studio 2017
 
@@ -10,14 +14,12 @@ build_script:
   - appveyor AddCompilationMessage "Building miniupnpc"
   - mingw32-make -f Makefile.mingw
   - mingw32-make -f Makefile.mingw pythonmodule PYTHON=C:\Python37\python
-#  - upnpc-static.exe -l
 
 after_build:
   - 7z a ..\miniupnpc-%APPVEYOR_BUILD_VERSION%.zip *.exe *.dll *.a *.lib
-  - 7z a ..\miniupnpc-python-%APPVEYOR_BUILD_VERSION%.zip build\ dist\
 
 artifacts:
   - path: miniupnpc-$(appveyor_build_version).zip
     name: miniupnpc binaries
-  - path: miniupnpc-python-$(appveyor_build_version).zip
+  - path: miniupnpc/dist/miniupnpc-$(APP_VERSION)-py3.7-win32.egg
     name: miniupnpc python module

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '2.1.{build}'
 
+image: Visual Studio 2017
+
 install:
   - set PATH=%PATH%;C:\msys64\mingw32\bin
 
@@ -7,7 +9,7 @@ build_script:
   - cd miniupnpc
   - appveyor AddCompilationMessage "Building miniupnpc"
   - mingw32-make -f Makefile.mingw
-  - mingw32-make -f Makefile.mingw pythonmodule PYTHON=C:\Python27\python
+  - mingw32-make -f Makefile.mingw pythonmodule PYTHON=C:\Python37\python
 #  - upnpc-static.exe -l
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ image: Visual Studio 2017
 
 install:
   - set PATH=%PATH%;C:\msys64\mingw32\bin
+  # We need wheel installed to build wheels
+  - "%PYTHON_VER%.exe -m pip install wheel"
 
 build_script:
   - cd miniupnpc
@@ -31,5 +33,7 @@ after_build:
 artifacts:
   - path: miniupnpc-$(appveyor_build_version).zip
     name: miniupnpc binaries
-  - path: miniupnpc/dist/miniupnpc-$(APP_VERSION)-*-win32.egg
-    name: miniupnpc python module
+  - path: miniupnpc/dist/miniupnpc-*.whl
+    name: miniupnpc python wheel (self-contained)
+  - path: miniupnpc/dist/miniupnpc-*.egg
+    name: miniupnpc python egg (self-contained)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,15 @@
 environment:
   APP_VERSION: '2.1'
+  matrix:
+    - PYTHON_VER: C:\Python27\python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      SETUP_COMPILER_FLAG: --compiler=mingw32
+    - PYTHON_VER: C:\Python35\python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      SETUP_COMPILER_FLAG:
+    - PYTHON_VER: C:\Python37\python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      SETUP_COMPILER_FLAG:
 
 
 version: '$(APP_VERSION).{build}'
@@ -13,7 +23,7 @@ build_script:
   - cd miniupnpc
   - appveyor AddCompilationMessage "Building miniupnpc"
   - mingw32-make -f Makefile.mingw
-  - mingw32-make -f Makefile.mingw pythonmodule PYTHON=C:\Python37\python
+  - mingw32-make -f Makefile.mingw pythonmodule PYTHON=%PYTHON_VER%
 
 after_build:
   - 7z a ..\miniupnpc-%APPVEYOR_BUILD_VERSION%.zip *.exe *.dll *.a *.lib
@@ -21,5 +31,5 @@ after_build:
 artifacts:
   - path: miniupnpc-$(appveyor_build_version).zip
     name: miniupnpc binaries
-  - path: miniupnpc/dist/miniupnpc-$(APP_VERSION)-py3.7-win32.egg
+  - path: miniupnpc/dist/miniupnpc-$(APP_VERSION)-*-win32.egg
     name: miniupnpc python module

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -46,7 +46,7 @@ libminiupnpc.a:	$(OBJS)
 	$(AR) cr $@ $?
 
 pythonmodule:	libminiupnpc.a
-	$(PYTHON) setupmingw32.py build --compiler=mingw32
+	$(PYTHON) setupmingw32.py build
 	$(PYTHON) setupmingw32.py install --skip-build
 
 miniupnpc.dll:	libminiupnpc.a $(OBJSDLL)

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -49,6 +49,7 @@ libminiupnpc.a:	$(OBJS)
 pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py build $(SETUP_COMPILER_FLAG)
 	$(PYTHON) setupmingw32.py install --skip-build
+	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
 
 miniupnpc.dll:	libminiupnpc.a $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -8,6 +8,7 @@
 # make -f Makefile.mingw DLLWRAP=mingw32-dllwrap CC=mingw32-gcc AR=mingw32-ar
 #
 CC ?= gcc
+SETUP_COMPILER_FLAG?=
 DLLWRAP = dllwrap
 SH = /bin/sh
 ifeq ($(OS),Windows_NT)
@@ -46,7 +47,7 @@ libminiupnpc.a:	$(OBJS)
 	$(AR) cr $@ $?
 
 pythonmodule:	libminiupnpc.a
-	$(PYTHON) setupmingw32.py build
+	$(PYTHON) setupmingw32.py build $(SETUP_COMPILER_FLAG)
 	$(PYTHON) setupmingw32.py install --skip-build
 
 miniupnpc.dll:	libminiupnpc.a $(OBJSDLL)

--- a/miniupnpc/setupmingw32.py
+++ b/miniupnpc/setupmingw32.py
@@ -22,7 +22,7 @@ setup(name="miniupnpc",
       description='miniUPnP client',
       ext_modules=[
          Extension(name="miniupnpc", sources=["miniupnpcmodule.c"],
-                   libraries=["ws2_32", "iphlpapi"],
+                   libraries=["ws2_32", "iphlpapi", "legacy_stdio_definitions"],
                    extra_objects=["libminiupnpc.a"])
       ])
 

--- a/miniupnpc/setupmingw32.py
+++ b/miniupnpc/setupmingw32.py
@@ -6,6 +6,13 @@
 #
 # python script to build the miniupnpc module under windows (using mingw32)
 #
+import sys
+
+if (sys.version_info.major * 10 +  sys.version_info.minor) >= 35:
+        compat_lib = ["legacy_stdio_definitions"]
+else:
+        compat_lib = []
+
 try:
         from setuptools import setup, Extension
 except ImportError:
@@ -22,7 +29,7 @@ setup(name="miniupnpc",
       description='miniUPnP client',
       ext_modules=[
          Extension(name="miniupnpc", sources=["miniupnpcmodule.c"],
-                   libraries=["ws2_32", "iphlpapi", "legacy_stdio_definitions"],
+                   libraries=["ws2_32", "iphlpapi"] + compat_lib,
                    extra_objects=["libminiupnpc.a"])
       ])
 


### PR DESCRIPTION
# Changes
I reworked the Appveyor build process and introduced the following changes :
- The python module is built for Python 2.7 (as before), Python 3.5 and Python 3.7. Adding support for new python versions should be relatively easy.
- The python module is distributed both as a raw egg file (which existed previously but was buried in a zip file with other non-required binary files), and a wheel file (which seems to be the recommended distribution method for python modules now).

# Remarks
- I only tested the .egg and .whl files for Python 3.7 under Windows 7 32 bits, which is the environment I was interested in. The other builds completed without errors but may require further validation.
- One of the main fixes that allowed the Python 3 versions to build was to remove the --compiler directive given to setuptool : it then naturally used the MSVC compiler to build the module as it is the default compiler for modern python versions and it seems mingw32 does not play well with these versions. However I think the C part of the project was not affected and is still built using mingw32. So this means the MVSC-built python module is linking against the mingw-built upnpc libraries. I am actually surprised its works so well in practice (we may have to thank the strong C-ABI for that), but I am not whether it is by chance or it is a guaranty of the standard. Comments and insights are very welcome on that aspect.
- References to mingw are all over the project, in comments, config files etc. I did not touch those, but it would probably be worth checking if all these references are still valid since we now also use MSVC.