### PR TITLE
Fix error code for 708

### DIFF
--- a/miniupnpc/upnperrors.c
+++ b/miniupnpc/upnperrors.c
@@ -71,7 +71,7 @@ const char * strupnperror(int err)
 		s = "ProtocolWildcardingNotAllowed";
 		break;
 	case 708:
-		s = "WildcardNotPermittedInSrcIP";
+		s = "InvalidLayer2Address";
 		break;
 	case 709:
 		s = "NoPacketSent";


### PR DESCRIPTION
According to the specification
http://upnp.org/specs/gw/UPnP-gw-WANIPConnection-v2-Service.pdf, the
708 error code corresponds to InvalidLayer2Address. Also
WildcardNotPermittedInSrcIP is for 715 which is already properly mapped.