### PR TITLE
Rework nft_removeall.sh to preserve other nftables structures

### DIFF
--- a/miniupnpd/netfilter_nft/scripts/nft_init.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_init.sh
@@ -1,47 +1,23 @@
 #!/bin/sh
+#
+# establish the chains that miniupnpd will update dynamically
+#
+# 'add' doesn't raise an error if the object already exists. 'create' does.
+#
 
-nft list table nat > /dev/null
-nft_nat_exists=$?
-nft list table inet filter > /dev/null
-nft_filter_exists=$?
-#nft list table inet mangle > /dev/null
-#nft_mangle_exists=$?
+#opts="--echo"
 
-if [ $nft_nat_exists -eq "1" ]; then
-	echo "create nat"
-	nft "add table nat"
-fi
-if [ $nft_filter_exists -eq "1" ]; then
-	echo "create filter"
-	nft "add table inet filter"
-fi
-#if [ $nft_mangle_exists -eq "1" ]; then
-#	echo "create mangle"
-#	nft "add table mangle"
-#fi
+echo "create nat table"
+nft ${opts} add table nat
 
-nft list chain nat MINIUPNPD > /dev/null
-nft_nat_miniupnpd_exists=$?
-nft list chain nat MINIUPNPD-POSTROUTING > /dev/null
-nft_nat_miniupnpd_pcp_peer_exists=$?
-nft list chain inet filter MINIUPNPD > /dev/null
-nft_filter_miniupnpd_exists=$?
-#nft list chain inet mangle MINIUPNPD > /dev/null
-#nft_mangle_miniupnpd_exists=$?
+echo "create chain in nat table"
+nft ${opts} add chain nat MINIUPNPD
 
-if [ $nft_nat_miniupnpd_exists -eq "1" ]; then
-	echo "create chain in nat"
-	nft "add chain nat MINIUPNPD"
-fi
-if [ $nft_nat_miniupnpd_pcp_peer_exists -eq "1" ]; then
-	echo "create pcp peer chain in nat"
-	nft "add chain nat MINIUPNPD-POSTROUTING"
-fi
-if [ $nft_filter_miniupnpd_exists -eq "1" ]; then
-	echo "create chain in filter "
-	nft "add chain inet filter MINIUPNPD"
-fi
-#if [ $nft_mangle_miniupnpd_exists -eq "1" ]; then
-#	echo "create chain in mangle"
-#	nft "add chain inet mangle MINIUPNPD"
-#fi
+echo "create pcp peer chain in nat table"
+nft ${opts} add chain nat MINIUPNPD-POSTROUTING
+
+echo "create filter table"
+nft ${opts} add table inet filter
+
+echo "create chain in filter table"
+nft ${opts} add chain inet filter MINIUPNPD

--- a/miniupnpd/netfilter_nft/scripts/nft_removeall.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_removeall.sh
@@ -1,4 +1,44 @@
 #!/bin/sh
+#
+# Undo the things nft_init.sh did
+#
+# Do not disturb other existing structures in nftables, e.g. those created by firewalld
+#
 
-# Remove all rules in nft not just miniupnpd
-nft flush ruleset
+nft --check list table nat > /dev/null 2>&1
+if [ $? -eq "0" ]; then
+{
+	# nat table exists, so first remove the chains we added
+	nft --check list chain nat MINIUPNPD > /dev/null 2>&1
+	if [ $? -eq "0" ]; then
+		echo "Remove chain from nat table"
+		nft delete chain nat MINIUPNPD
+	fi
+
+	nft --check list chain nat MINIUPNPD-POSTROUTING > /dev/null 2>&1
+	if [ $? -eq "0" ]; then
+		echo "Remove pcp peer chain from nat table"
+		nft delete chain nat MINIUPNPD-POSTROUTING
+	fi
+
+	# then remove the table itself
+	echo "Remove nat table"
+	nft delete table nat
+}
+fi
+
+nft --check list table inet filter > /dev/null 2>&1
+if [ $? -eq "0" ]; then
+{
+	# filter table exists, so first remove the chain we added
+	nft --check list chain inet filter MINIUPNPD > /dev/null 2>&1
+	if [ $? -eq "0" ]; then
+		echo "Remove chain from filter table"
+		nft delete chain inet filter MINIUPNPD
+	fi
+
+	# then remove the table itself
+	echo "Remove filter table"
+	nft delete table inet filter
+}
+fi


### PR DESCRIPTION
Rework nft_removeall.sh to preserve nftables structures that miniupnpd didn't add. Important for firewalld and sshguard co-existance.