### PR TITLE
Update case statements to fix compiler 'fall through' warnings

### DIFF
--- a/miniupnpd/Makefile.linux
+++ b/miniupnpd/Makefile.linux
@@ -21,6 +21,7 @@
 # ./configure them and build them then miniupnpd will build using :
 # $ IPTABLESPATH=/path/to/iptables-1.4.1 make -f Makefile.linux
 #
+CONFIG_OPTIONS += --firewall=iptables
 #CFLAGS = -O -g -DDEBUG
 CFLAGS ?= -Os
 CFLAGS += -fno-strict-aliasing
@@ -193,6 +194,7 @@ EXECUTABLES = miniupnpd testupnpdescgen testgetifstats \
 all:	$(EXECUTABLES)
 
 clean:
+	$(RM) config.h
 	$(RM) $(ALLOBJS)
 	$(RM) $(EXECUTABLES)
 	$(RM) testupnpdescgen.o testgetifstats.o

--- a/miniupnpd/Makefile.linux_nft
+++ b/miniupnpd/Makefile.linux_nft
@@ -16,6 +16,7 @@
 # (default INSTALLPREFIX is /usr)
 #
 #
+CONFIG_OPTIONS += --firewall=nftables
 CFLAGS = -O -g #-DDEBUG
 CFLAGS ?= -Os
 CFLAGS += -fno-strict-aliasing
@@ -108,6 +109,7 @@ EXECUTABLES = miniupnpd miniupnpdctl \
 all:	$(EXECUTABLES)
 
 clean:
+	$(RM) config.h
 	$(RM) $(ALLOBJS)
 	$(RM) $(EXECUTABLES)
 	$(RM) testupnpdescgen.o testgetifstats.o

--- a/miniupnpd/genconfig.sh
+++ b/miniupnpd/genconfig.sh
@@ -32,6 +32,8 @@ case "$argv" in
 			exit 1
 		fi ;;
 	--disable-pppconn) DISABLEPPPCONN=1 ;;
+	--firewall=*)
+	    FW=$(echo $argv | cut -d= -f2) ;;
 	--help|-h)
 		echo "Usage : $0 [options]"
 		echo " --ipv6      enable IPv6"
@@ -43,6 +45,7 @@ case "$argv" in
 		echo " --portinuse enable port in use check"
 		echo " --uda-version=x.x  set advertised UPnP version (default to ${UPNP_VERSION_MAJOR}.${UPNP_VERSION_MINOR})"
 		echo " --disable-pppconn  disable WANPPPConnection"
+		echo " --firewall=<name>  force the firewall type (only for linux)"
 		exit 1
 		;;
 	*)
@@ -316,11 +319,14 @@ case $OS_NAME in
 			esac
 		fi
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}
-		# Would be better to check for actual presence of nftable rules, but that requires root privileges
-		if [ -x "$(command -v nft)" ]; then
-			FW=nftables
-		else
-			FW=iptables
+		if [ -z ${FW} ]; then
+			# test the current environment to determine which to use
+			# Would be better to check for actual presence of nftable rules, but that requires root privileges
+			if [ -x "$(command -v nft)" ]; then
+				FW=nftables
+			else
+				FW=iptables
+			fi
 		fi
 		V6SOCKETS_ARE_V6ONLY=`/sbin/sysctl -n net.ipv6.bindv6only`
 		;;

--- a/miniupnpd/linux/ifacewatcher.c
+++ b/miniupnpd/linux/ifacewatcher.c
@@ -49,6 +49,7 @@
 #include <signal.h>
 
 #include "../config.h"
+#include "../macros.h"
 
 #ifdef USE_IFACEWATCHER
 
@@ -280,6 +281,7 @@ ProcessInterfaceWatchNotify(int s)
 		switch(nlhdr->nlmsg_type) {
 		case RTM_DELLINK:
 			is_del = 1;
+			FALL_THROUGH;
 		case RTM_NEWLINK:
 #if 0
 /* disabled at the moment */
@@ -295,6 +297,7 @@ ProcessInterfaceWatchNotify(int s)
 			break;
 		case RTM_DELADDR:
 			is_del = 1;
+			FALL_THROUGH;
 		case RTM_NEWADDR:
 			/* see /usr/include/linux/netlink.h
 			 * and /usr/include/linux/rtnetlink.h */

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -394,6 +394,7 @@ parse_rule_payload(struct nftnl_expr *e, rule_t *r)
 			*regptr = RULE_REG_IP6_SD_ADDR;
 			return;
 		}
+		break;
 	case NFT_PAYLOAD_TRANSPORT_HEADER:
 		if (offset == offsetof(struct tcphdr, dest) &&
 		    len == sizeof(uint16_t)) {
@@ -404,6 +405,7 @@ parse_rule_payload(struct nftnl_expr *e, rule_t *r)
 			*regptr = RULE_REG_TCP_SD_PORT;
 			return;
 		}
+		break;
 	}
 	syslog(LOG_DEBUG,
 	       "Unsupport payload: (dreg:%d, base:%d, offset:%d, len:%d)",
@@ -440,18 +442,21 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP_SRC_ADDR:
 		if (data_len == sizeof(in_addr_t) && op == NFT_CMP_EQ) {
 			r->rhost = *(in_addr_t *)data_val;
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP6_SRC_ADDR:
 		if (data_len == sizeof(struct in6_addr) && op == NFT_CMP_EQ) {
 			r->rhost6 = *(struct in6_addr *)data_val;
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP_DEST_ADDR:
 		if (data_len == sizeof(in_addr_t) && op == NFT_CMP_EQ) {
 			if (r->type == RULE_FILTER) {
@@ -462,6 +467,7 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP6_DEST_ADDR:
 		if (data_len == sizeof(struct in6_addr) && op == NFT_CMP_EQ) {
 			if (r->type == RULE_FILTER) {
@@ -472,6 +478,7 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP_SD_ADDR:
 		if (data_len == sizeof(in_addr_t) * 2 && op == NFT_CMP_EQ) {
 			addrp = (in_addr_t *)data_val;
@@ -480,6 +487,7 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP6_SD_ADDR:
 		if (data_len == sizeof(struct in6_addr) * 2 && op == NFT_CMP_EQ) {
 			addrp6 = (struct in6_addr *)data_val;
@@ -488,6 +496,7 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_IP_PROTO:
 	case RULE_REG_IP6_PROTO:
 		if (data_len == sizeof(uint8_t) && op == NFT_CMP_EQ) {
@@ -495,12 +504,14 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_TCP_DPORT:
 		if (data_len == sizeof(uint16_t) && op == NFT_CMP_EQ) {
 			r->eport = ntohs(*(uint16_t *)data_val);
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	case RULE_REG_TCP_SD_PORT:
 		if (data_len == sizeof(uint16_t) * 2 && op == NFT_CMP_EQ) {
 			ports = (uint16_t *)data_val;
@@ -509,6 +520,7 @@ parse_rule_cmp(struct nftnl_expr *e, rule_t *r) {
 			r->reg1_type = RULE_REG_NONE;
 			return;
 		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
A couple seem intentional (linux/ifacewatcher.c). Most look like they were unintentionally omitted (netfilter_nft/nftnlrdr_misc.c).

Resubmitted without unintended indentation changes included in previous pull request.