### PR TITLE
Significant updates to nftables support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,10 @@ script:
       make -f $MAKEFILE depend;
     fi
   - 'CONFIG_OPTIONS="--ipv6 --igd2" make -f $MAKEFILE -j3'
-  - 'if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PROJECT" = "miniupnpd" ]; then make -f Makefile.linux_nft ; fi'
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PROJECT" = "miniupnpd" ]; then
+      make -f Makefile.linux_nft clean ;
+      make -f Makefile.linux_nft ;
+    fi
   - make -f $MAKEFILE check
   - 'if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$PROJECT" = "miniupnpd" ]; then make -f $MAKEFILE dox ; fi'
   - if [ "$PROJECT" = "miniupnpc" ]; then

--- a/miniupnpd/Makefile.linux_nft
+++ b/miniupnpd/Makefile.linux_nft
@@ -41,11 +41,10 @@ MANINSTALLDIR = $(INSTALLPREFIX)/share/man/man8
 
 BASEOBJS = miniupnpd.o upnphttp.o upnpdescgen.o upnpsoap.o \
            upnpreplyparse.o minixml.o portinuse.o \
-           upnpredirect.o getifaddr.o daemonize.o upnpglobalvars.o \
+           upnpredirect.o getifaddr.o daemonize.o \
            options.o upnppermissions.o minissdp.o natpmp.o pcpserver.o \
-           upnpevents.o upnputils.o getconnstatus.o \
-           upnpstun.o \
-           upnppinhole.o pcplearndscp.o asyncsendto.o
+           upnpglobalvars.o upnpevents.o upnputils.o getconnstatus.o \
+           upnpstun.o upnppinhole.o pcplearndscp.o asyncsendto.o
 
 LNXOBJS = linux/getifstats.o linux/ifacewatcher.o linux/getroute.o
 NETFILTEROBJS = netfilter_nft/nftnlrdr.o netfilter_nft/nftpinhole.o \
@@ -233,9 +232,9 @@ linux/ifacewatcher.o: miniupnpdtypes.h getifaddr.h upnpglobalvars.h
 linux/ifacewatcher.o: upnppermissions.h natpmp.h
 linux/getroute.o: getroute.h upnputils.h
 netfilter_nft/nftnlrdr.o: macros.h config.h netfilter_nft/nftnlrdr.h commonrdr.h
-netfilter_nft/nftnlrdr.o: config.h upnpglobalvars.h upnppermissions.h
+netfilter_nft/nftnlrdr.o: config.h upnppermissions.h
 netfilter_nft/nftnlrdr.o: miniupnpdtypes.h
-netfilter_nft/nftpinhole.o: config.h netfilter_nft/nftpinhole.h upnpglobalvars.h
+netfilter_nft/nftpinhole.o: config.h netfilter_nft/nftpinhole.h
 netfilter_nft/nftpinhole.o: upnppermissions.h config.h miniupnpdtypes.h
 testupnpdescgen.o: macros.h config.h upnpdescgen.h upnpdescstrings.h
 testupnpdescgen.o: getifaddr.h

--- a/miniupnpd/commonrdr.h
+++ b/miniupnpd/commonrdr.h
@@ -73,7 +73,7 @@ update_portmapping_desc_timestamp(const char * ifname,
 typedef enum {
 	RDR_TABLE_NAME,
 	RDR_NAT_PREROUTING_CHAIN_NAME,
-	RDR NAT_POSTROUTING_CHAIN_NAME,
+	RDR_NAT_POSTROUTING_CHAIN_NAME,
 	RDR_FORWARD_CHAIN_NAME,
 } rdr_name_type;
 

--- a/miniupnpd/commonrdr.h
+++ b/miniupnpd/commonrdr.h
@@ -65,16 +65,22 @@ update_portmapping_desc_timestamp(const char * ifname,
                    const char * desc, unsigned int timestamp);
 
 #ifdef USE_NFTABLES
-/* only provided by nftables implementation at the moment */
+/*
+ * only provided by nftables implementation at the moment.
+ * Should be implemented for iptables too, for consistency
+ */
 
 typedef enum {
-	TABLE_NAME,
-	TABLE4_NAME,
-	TABLE6_NAME,
-	NAT_CHAIN_NAME,
-	NAT_POSTROUTING_CHAIN_NAME,
-	FORWARD_CHAIN_NAME,
+	RDR_TABLE_NAME,
+	RDR_NAT_PREROUTING_CHAIN_NAME,
+	RDR NAT_POSTROUTING_CHAIN_NAME,
+	RDR_FORWARD_CHAIN_NAME,
 } rdr_name_type;
+
+/*
+ * used by the config file parsing in the core
+ * to set
+ */
 
 int set_rdr_name( rdr_name_type param, const char * string );
 

--- a/miniupnpd/commonrdr.h
+++ b/miniupnpd/commonrdr.h
@@ -64,4 +64,20 @@ update_portmapping_desc_timestamp(const char * ifname,
                    unsigned short eport, int proto,
                    const char * desc, unsigned int timestamp);
 
+#ifdef USE_NFTABLES
+/* only provided by nftables implementation at the moment */
+
+typedef enum {
+	TABLE_NAME,
+	TABLE4_NAME,
+	TABLE6_NAME,
+	NAT_CHAIN_NAME,
+	NAT_POSTROUTING_CHAIN_NAME,
+	FORWARD_CHAIN_NAME,
+} rdr_name_type;
+
+int set_rdr_name( rdr_name_type param, const char * string );
+
+#endif
+
 #endif

--- a/miniupnpd/linux/miniupnpd.service
+++ b/miniupnpd/linux/miniupnpd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MiniUPnPD
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/miniupnpd
+ExecStop=kill `cat /var/run/miniupnpd.pid`
+
+[Install]
+WantedBy=multi-user.target

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1269,13 +1269,13 @@ init(int argc, char * * argv, struct runtime_vars * v)
 #ifdef USE_NETFILTER
 #ifdef USE_NFTABLES
 			case UPNPFORWARDCHAIN:
-				set_rdr_name(FORWARD_CHAIN_NAME, ary_options[i].value);
+				set_rdr_name(RDR_FORWARD_CHAIN_NAME, ary_options[i].value);
 				break;
 			case UPNPNATCHAIN:
-				set_rdr_name(NAT_CHAIN_NAME, ary_options[i].value);
+				set_rdr_name(RDR_NAT_PREROUTING_CHAIN_NAME, ary_options[i].value);
 				break;
 			case UPNPNATPOSTCHAIN:
-				set_rdr_name(NAT_POSTROUTING_CHAIN_NAME, ary_options[i].value);
+				set_rdr_name(RDR_NAT_POSTROUTING_CHAIN_NAME, ary_options[i].value);
 				break;
 #else
 			case UPNPFORWARDCHAIN:

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1267,6 +1267,17 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				break;
 #endif	/* ENABLE_MANUFACTURER_INFO_CONFIGURATION */
 #ifdef USE_NETFILTER
+#ifdef USE_NFTABLES
+			case UPNPFORWARDCHAIN:
+				set_rdr_name(FORWARD_CHAIN_NAME, ary_options[i].value);
+				break;
+			case UPNPNATCHAIN:
+				set_rdr_name(NAT_CHAIN_NAME, ary_options[i].value);
+				break;
+			case UPNPNATPOSTCHAIN:
+				set_rdr_name(NAT_POSTROUTING_CHAIN_NAME, ary_options[i].value);
+				break;
+#else
 			case UPNPFORWARDCHAIN:
 				miniupnpd_forward_chain = ary_options[i].value;
 				break;
@@ -1276,7 +1287,8 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPNATPOSTCHAIN:
 				miniupnpd_nat_postrouting_chain = ary_options[i].value;
 				break;
-#endif	/* USE_NETFILTER */
+#endif    /* else USE_NFTABLES */
+#endif    /* USE_NETFILTER */
 			case UPNPNOTIFY_INTERVAL:
 				v->notify_interval = atoi(ary_options[i].value);
 				break;
@@ -2900,6 +2912,8 @@ shutdown:
 #ifndef DISABLE_CONFIG_FILE
 	freeoptions();
 #endif
+
+	shutdown_redirect();
 
 	return 0;
 }

--- a/miniupnpd/netfilter_nft/Makefile
+++ b/miniupnpd/netfilter_nft/Makefile
@@ -11,9 +11,9 @@ clean:
 	$(RM) *.o testnftnlcrdr testnftpinhole testnftnlrdr_peer \
 		test_nfct_get testnftnlrdr 
 
-testnftnlrdr:	nftnlrdr.o nftnlrdr_misc.o testnftnlrdr.o upnpglobalvars.o $(LIBS)
+testnftnlrdr:	nftnlrdr.o nftnlrdr_misc.o testnftnlrdr.o $(LIBS)
 
-testnftpinhole:	nftpinhole.o nftnlrdr_misc.o testnftpinhole.o upnpglobalvars.o $(LIBS)
+testnftpinhole:	nftpinhole.o nftnlrdr_misc.o testnftpinhole.o $(LIBS)
 
 test_nfct_get:	test_nfct_get.o test_nfct_get.o -lmnl -lnetfilter_conntrack
 
@@ -29,5 +29,3 @@ nftnlrdr_misc.o:	nftnlrdr_misc.c
 
 nftpinhole.o:		nftpinhole.c nftpinhole.h
 
-upnpglobalvars.o:	../upnpglobalvars.c ../upnpglobalvars.h
-	$(CC) -c -o $@ $<

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -72,7 +72,7 @@ init_redirect(void) {
 	result = table_op(NFT_MSG_NEWTABLE, NFPROTO_INET, nft_table);
 	if (result == 0) {
 		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_INET, nft_table,
-						  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER);
+						  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER - 25);
 	}
 
 	/* 'ip' family */
@@ -110,7 +110,7 @@ shutdown_redirect(void) {
 
 	/* 'inet' family */
 	result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_INET, nft_table,
-					  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER);
+					  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER - 25);
 	if (result == 0) {
 		result = table_op(NFT_MSG_DELTABLE, NFPROTO_INET, nft_table);
 	}

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -155,16 +155,16 @@ set_rdr_name(rdr_name_type param, const char *string) {
 		return -1;
 	}
 	switch (param) {
-	case TABLE_NAME:
+	case RDR_TABLE_NAME:
 		nft_table = string;
 		break;
-	case NAT_CHAIN_NAME:
+	case RDR_NAT_PREROUTING_CHAIN_NAME:
 		nft_prerouting_chain = string;
 		break;
-	case NAT_POSTROUTING_CHAIN_NAME:
+	case RDR_NAT_POSTROUTING_CHAIN_NAME:
 		nft_postrouting_chain = string;
 		break;
-	case FORWARD_CHAIN_NAME:
+	case RDR_FORWARD_CHAIN_NAME:
 		nft_forward_chain = string;
 		break;
 	default:

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -77,27 +77,27 @@ init_redirect(void) {
 
 	/* 'ip' family */
 	if (result == 0) {
-		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV4, nft_table4);
+		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV4, nft_table);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table4,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table,
 						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table4,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 
 	/* 'ip6' family */
 	if (result == 0) {
-		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV6, nft_table6);
+		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV6, nft_table);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table6,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table,
 						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table6,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 
@@ -116,27 +116,27 @@ shutdown_redirect(void) {
 	}
 
 	/* 'ip' family */
-	result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table4,
+	result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table,
 					  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
 	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table4,
+		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 	if (result == 0) {
-		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV4, nft_table4);
+		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV4, nft_table);
 	}
 
 	/* 'ip6' family */
 	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table6,
+		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table,
 						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table6,
+		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 	if (result == 0) {
-		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV6, nft_table6);
+		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV6, nft_table);
 	}
 
 	finish_batch();
@@ -156,12 +156,6 @@ set_rdr_name(rdr_name_type param, const char *string) {
 	switch (param) {
 	case TABLE_NAME:
 		nft_table = string;
-		break;
-	case TABLE4_NAME:
-		nft_table4 = string;
-		break;
-	case TABLE6_NAME:
-		nft_table6 = string;
 		break;
 	case NAT_CHAIN_NAME:
 		nft_prerouting_chain = string;

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -3,6 +3,7 @@
  * MiniUPnP project
  * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
  * (c) 2015 Tomofumi Hayashi
+ * (c) 2019 Paul Chambers
  *
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution.

--- a/miniupnpd/netfilter_nft/nftnlrdr.h
+++ b/miniupnpd/netfilter_nft/nftnlrdr.h
@@ -2,6 +2,7 @@
  * MiniUPnP project
  * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
  * (c) 2015 Tomofumi Hayashi
+ * (c) 2019 Paul Chambers
  * 
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution.

--- a/miniupnpd/netfilter_nft/nftnlrdr.h
+++ b/miniupnpd/netfilter_nft/nftnlrdr.h
@@ -11,6 +11,7 @@
 #define NFTNLRDR_H_INCLUDED
 
 #include "../commonrdr.h"
+
 int init_redirect(void);
 void shutdown_redirect(void);
 

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -64,8 +64,6 @@
 #define RULE_CACHE_VALID    1
 
 const char * nft_table = "miniupnpd";
-const char * nft_table4 = "miniupnpd4";
-const char * nft_table6 = "miniupnpd6";
 const char * nft_prerouting_chain = "prerouting";
 const char * nft_postrouting_chain = "postrouting";
 const char * nft_forward_chain = "forward";
@@ -656,7 +654,7 @@ table_cb(const struct nlmsghdr *nlh, void *data)
 void
 refresh_nft_cache_filter(void) {
 	if (rule_list_filter_validate != RULE_CACHE_VALID) {
-		refresh_nft_cache(&head_filter, nft_table4, nft_forward_chain, NFPROTO_INET);
+		refresh_nft_cache(&head_filter, nft_table, nft_forward_chain, NFPROTO_INET);
 		rule_list_filter_validate = RULE_CACHE_VALID;
 	}
 }
@@ -664,7 +662,7 @@ refresh_nft_cache_filter(void) {
 void
 refresh_nft_cache_peer(void) {
 	if (rule_list_peer_validate != RULE_CACHE_VALID) {
-		refresh_nft_cache(&head_peer, nft_table4, nft_postrouting_chain, NFPROTO_IPV4);
+		refresh_nft_cache(&head_peer, nft_table, nft_postrouting_chain, NFPROTO_IPV4);
 		rule_list_peer_validate = RULE_CACHE_VALID;
 	}
 }
@@ -673,7 +671,7 @@ void
 refresh_nft_cache_redirect(void)
 {
 	if (rule_list_redirect_validate != RULE_CACHE_VALID) {
-		refresh_nft_cache(&head_redirect, nft_table4, nft_prerouting_chain, NFPROTO_IPV4);
+		refresh_nft_cache(&head_redirect, nft_table, nft_prerouting_chain, NFPROTO_IPV4);
 		rule_list_redirect_validate = RULE_CACHE_VALID;
 	}
 }
@@ -935,9 +933,9 @@ rule_set_snat(uint8_t family, uint8_t proto,
 		return NULL;
 	}
 
-	nftnl_rule_set(r, NFTNL_RULE_TABLE, family == NFPROTO_IPV6 ? nft_table6 : nft_table4);
-	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_postrouting_chain);
 	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, family);
+	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
+	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_postrouting_chain);
 
 	if (descr != NULL) {
 		descr_len = strlen(descr);
@@ -1021,9 +1019,9 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 		return NULL;
 	}
 
-	nftnl_rule_set(r, NFTNL_RULE_TABLE, family == NFPROTO_IPV6 ? nft_table6 : nft_table4);
-	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_prerouting_chain);
 	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, family);
+	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
+	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_prerouting_chain);
 
 	if (descr != NULL) {
 		descr_len = strlen(descr);
@@ -1183,9 +1181,9 @@ rule_set_filter_common(struct nftnl_rule *r, uint8_t family, const char * ifname
 	uint32_t descr_len;
 	UNUSED(eport);
 
+	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, family);
 	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
 	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_forward_chain);
-	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, family);
 
 	if (descr != NULL) {
 		descr_len = strlen(descr);

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -1354,10 +1354,10 @@ chain_op(enum nf_tables_msg_types op, uint16_t family, const char * table,
         log_error("out of memory: %m");
         result = -2;
     } else {
-        nftnl_chain_set(chain, NFTNL_CHAIN_TABLE, table);
-        nftnl_chain_set(chain, NFTNL_CHAIN_NAME, name);
-        if (op == NFT_MSG_NEWCHAIN)
-		{
+		nftnl_chain_set_u32(chain, NFTNL_CHAIN_FAMILY, family);
+		nftnl_chain_set(chain, NFTNL_CHAIN_TABLE, table);
+		nftnl_chain_set(chain, NFTNL_CHAIN_NAME, name);
+		if (op == NFT_MSG_NEWCHAIN) {
 			nftnl_chain_set_str(chain, NFTNL_CHAIN_TYPE, type);
 			nftnl_chain_set_u32(chain, NFTNL_CHAIN_HOOKNUM, hooknum);
 			nftnl_chain_set_s32(chain, NFTNL_CHAIN_PRIO, priority);

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -597,7 +597,7 @@ table_cb(const struct nlmsghdr *nlh, void *data)
 					descr = (char *) nftnl_rule_get_data(t, NFTNL_RULE_USERDATA,
 														 &r->desc_len);
 					if (r->desc_len > 0)
-						r->desc = strdup(descr);
+						r->desc = strndup(descr, r->desc_len);
 
 					r->handle = *(uint32_t *) nftnl_rule_get_data(t,
 																  NFTNL_RULE_HANDLE,

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -921,7 +921,6 @@ rule_set_snat(uint8_t family, uint8_t proto,
 {
 	struct nftnl_rule *r = NULL;
 	uint16_t dport, sport;
-	uint32_t descr_len;
 	#ifdef DEBUG
 	char buf[8192];
 	#endif
@@ -937,10 +936,9 @@ rule_set_snat(uint8_t family, uint8_t proto,
 	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
 	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_postrouting_chain);
 
-	if (descr != NULL) {
-		descr_len = strlen(descr);
+	if (descr != NULL && *descr != '\0') {
 		nftnl_rule_set_data(r, NFTNL_RULE_USERDATA,
-				       descr, descr_len);
+							descr, strlen(descr));
 	}
 
 	/* Destination IP */
@@ -1006,7 +1004,6 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 	uint16_t dport;
 	uint64_t handle_num;
 	uint32_t if_idx;
-	uint32_t descr_len;
 	#ifdef DEBUG
 	char buf[8192];
 	#endif
@@ -1023,10 +1020,9 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
 	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_prerouting_chain);
 
-	if (descr != NULL) {
-		descr_len = strlen(descr);
+	if (descr != NULL && *descr != '\0') {
 		nftnl_rule_set_data(r, NFTNL_RULE_USERDATA,
-				       descr, descr_len);
+							descr, strlen(descr));
 	}
 
 	if (handle != NULL) {
@@ -1178,17 +1174,15 @@ rule_set_filter_common(struct nftnl_rule *r, uint8_t family, const char * ifname
 	uint16_t dport, sport;
 	uint64_t handle_num;
 	uint32_t if_idx;
-	uint32_t descr_len;
 	UNUSED(eport);
 
 	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, family);
 	nftnl_rule_set(r, NFTNL_RULE_TABLE, nft_table);
 	nftnl_rule_set(r, NFTNL_RULE_CHAIN, nft_forward_chain);
 
-	if (descr != NULL) {
-		descr_len = strlen(descr);
+	if (descr != NULL && *descr != '\0') {
 		nftnl_rule_set_data(r, NFTNL_RULE_USERDATA,
-				       descr, descr_len);
+							descr, strlen(descr));
 	}
 
 	if (handle != NULL) {
@@ -1362,9 +1356,12 @@ chain_op(enum nf_tables_msg_types op, uint16_t family, const char * table,
     } else {
         nftnl_chain_set(chain, NFTNL_CHAIN_TABLE, table);
         nftnl_chain_set(chain, NFTNL_CHAIN_NAME, name);
-		nftnl_chain_set_str(chain, NFTNL_CHAIN_TYPE, type);
-        nftnl_chain_set_u32(chain, NFTNL_CHAIN_HOOKNUM, hooknum);
-        nftnl_chain_set_s32(chain, NFTNL_CHAIN_PRIO, priority);
+        if (op == NFT_MSG_NEWCHAIN)
+		{
+			nftnl_chain_set_str(chain, NFTNL_CHAIN_TYPE, type);
+			nftnl_chain_set_u32(chain, NFTNL_CHAIN_HOOKNUM, hooknum);
+			nftnl_chain_set_s32(chain, NFTNL_CHAIN_PRIO, priority);
+		}
 
         batch = start_batch( buf, sizeof(buf));
         if (batch == NULL) {

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -4,6 +4,7 @@
  * http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
  * (c) 2015 Tomofumi Hayashi
  * (c) 2019 Thomas Bernard
+ * (c) 2019 Paul Chambers
  *
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution.
@@ -41,7 +42,6 @@
 #include "nftnlrdr_misc.h"
 #include "../macros.h"
 
-#define DEBUG 1
 
 #ifdef DEBUG
 #define d_printf(x) do { printf x; } while (0)
@@ -1308,7 +1308,7 @@ table_op( enum nf_tables_msg_types op, uint16_t family, const char * name)
 
     struct nftnl_table *table;
 
-	log_error("(%d, %d, %s)", op, family, name);
+	// log_debug("(%d, %d, %s)", op, family, name);
 
     table = nftnl_table_alloc();
     if (table == NULL) {
@@ -1347,7 +1347,7 @@ chain_op(enum nf_tables_msg_types op, uint16_t family, const char * table,
 
     struct nftnl_chain *chain;
 
-    log_error("(%d, %d, %s, %s, %s, %d, %d)", op, family, table, name, type, hooknum, priority);
+    // log_debug("(%d, %d, %s, %s, %s, %d, %d)", op, family, table, name, type, hooknum, priority);
 
     chain = nftnl_chain_alloc();
     if (chain == NULL) {

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.h
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.h
@@ -8,8 +8,13 @@
  */
 #include <sys/queue.h>
 
-#define NFT_TABLE_NAT  "nat"
-#define NFT_TABLE_FILTER  "filter"
+extern const char * nft_table;
+extern const char * nft_table4;
+extern const char * nft_table6;
+extern const char * nft_prerouting_chain;
+extern const char * nft_postrouting_chain;
+extern const char * nft_forward_chain;
+
 #define NFT_DESCR_SIZE 1024
 
 enum rule_reg_type { 
@@ -80,7 +85,7 @@ extern struct rule_list head_redirect;
 extern struct rule_list head_peer;
 
 int
-nft_send_request(struct nftnl_rule * rule, uint16_t cmd, enum rule_chain_type type);
+nft_send_rule(struct nftnl_rule * rule, uint16_t cmd, enum rule_chain_type type);
 struct nftnl_rule *
 rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 	      in_addr_t rhost, unsigned short eport,
@@ -109,8 +114,21 @@ rule_set_filter_common(struct nftnl_rule *r, uint8_t family, const char * ifname
 		uint8_t proto, unsigned short eport, unsigned short iport, 
 		unsigned short rport, const char *descr, const char *handle);
 struct nftnl_rule *rule_del_handle(rule_t *r);
-void reflesh_nft_cache_filter(void);
-void reflesh_nft_cache_redirect(void);
-void reflesh_nft_cache_peer(void);
-void reflesh_nft_cache(struct rule_list *head, char *table, const char *chain, uint32_t family);
+void refresh_nft_cache_filter(void);
+void refresh_nft_cache_redirect(void);
+void refresh_nft_cache_peer(void);
+void refresh_nft_cache(struct rule_list *head, const char *table, const char *chain, uint32_t family);
 void print_rule(rule_t *r);
+
+int
+table_op(enum nf_tables_msg_types op, uint16_t family, const char * name);
+int
+chain_op(enum nf_tables_msg_types op, uint16_t family, const char * table,
+         const char * name, const char * type, uint32_t hooknum, signed int priority );
+
+struct mnl_nlmsg_batch *
+start_batch( char *buf, size_t buf_size);
+int
+send_batch(struct mnl_nlmsg_batch * batch);
+void
+finish_batch(void);

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.h
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.h
@@ -2,7 +2,8 @@
  * MiniUPnP project
  * http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
  * (c) 2015 Tomofumi Hayashi
- * 
+ * (c) 2019 Paul Chambers
+ *
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution.
  */

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.h
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.h
@@ -9,8 +9,6 @@
 #include <sys/queue.h>
 
 extern const char * nft_table;
-extern const char * nft_table4;
-extern const char * nft_table6;
 extern const char * nft_prerouting_chain;
 extern const char * nft_postrouting_chain;
 extern const char * nft_forward_chain;

--- a/miniupnpd/upnpglobalvars.c
+++ b/miniupnpd/upnpglobalvars.c
@@ -109,7 +109,7 @@ const char * queue = 0;
 const char * tag = 0;
 #endif
 
-#ifdef USE_NETFILTER
+#ifdef USE_IPTABLES
 /* chain names to use in the nat and filter tables. */
 
 /* iptables -t nat -N MINIUPNPD

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -142,7 +142,7 @@ extern const char * queue;
 extern const char * tag;
 #endif
 
-#ifdef USE_NETFILTER
+#ifdef USE_IPTABLES
 extern const char * miniupnpd_nat_chain;
 extern const char * miniupnpd_nat_postrouting_chain;
 extern const char * miniupnpd_forward_chain;


### PR DESCRIPTION
Branch with significant changes that updates nftables support in miniupnpd to work with current versions of libnftnl (and nftables underneath). Also includes some maintainability and readability improvements.

Also tested independently by @4np. I believe this fixes issue #397 