### PR TITLE
Add Haiku Support

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -96,6 +96,12 @@ if (WIN32)
 #  find_library (NSL_LIBRARY NAMES nsl)
 #  find_library (RESOLV_LIBRARY NAMES resolv)
 #  set (LDLIBS ${SOCKET_LIBRARY} ${NSL_LIBRARY} ${RESOLV_LIBRARY} ${LDLIBS})
+elseif (HAIKU)
+  target_link_libraries(miniupnpc-private INTERFACE network)
+  find_library (SOCKET_LIBRARY NAMES network)
+  find_library (NSL_LIBRARY NAMES network)
+  find_library (RESOLV_LIBRARY NAMES network)
+  set (LDLIBS ${SOCKET_LIBRARY} ${NSL_LIBRARY} ${RESOLV_LIBRARY} ${LDLIBS})  
 endif ()
 
 

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -62,13 +62,13 @@ struct sockaddr_un {
 
 #include "miniupnpc_socketdef.h"
 
-#if !defined(__DragonFly__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__APPLE__) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__sun) && !defined(__GNU__) && !defined(__FreeBSD_kernel__)
+#if !defined(__DragonFly__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__APPLE__) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__sun) && !defined(__GNU__) && !defined(__FreeBSD_kernel__) && !defined(__HAIKU__)
 #define HAS_IP_MREQN
 #endif
 
 #if !defined(HAS_IP_MREQN) && !defined(_WIN32)
 #include <sys/ioctl.h>
-#if defined(__sun)
+#if defined(__sun) || defined(__HAIKU__)
 #include <sys/sockio.h>
 #endif
 #endif

--- a/miniupnpc/portlistingparse.c
+++ b/miniupnpc/portlistingparse.c
@@ -12,6 +12,10 @@
 #include "portlistingparse.h"
 #include "minixml.h"
 
+#if defined(__HAIKU__)
+#define atoui atoui2
+#endif 
+
 /* list of the elements */
 static const struct {
 	const portMappingElt code;


### PR DESCRIPTION
These changes shouldn't conflict with anything, and I don't expect the rename of atoui to atoui2 to affect other systems. (On Haiku, atoui was already defined in stdlib)