### PR TITLE
fix: TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/miniupnpc/testupnpigd.py
+++ b/miniupnpc/testupnpigd.py
@@ -29,7 +29,7 @@ class handler_class(BaseHTTPRequestHandler):
 	def do_GET(self):
 		self.send_response(200)
 		self.end_headers()
-		self.wfile.write("OK MON GARS")
+		self.wfile.write(b"OK MON GARS")
 
 # create the object
 u = miniupnpc.UPnP()


### PR DESCRIPTION
fix: TypeError: a bytes-like object is required, not 'str'
*write function's parameter type is bytes.