### PR TITLE
miniupnpd: typo fix and update snat rules

### DIFF
--- a/miniupnpd/netfilter/iptcrdr.c
+++ b/miniupnpd/netfilter/iptcrdr.c
@@ -858,7 +858,7 @@ delete_redirect_and_filter_rules(unsigned short eport, int proto)
 				{
 					const struct ipt_udp * info;
 					info = (const struct ipt_udp *)match->data;
-					iport = info->dpts[0];
+					iport = info->spts[0];
 				}
 
 				index = i;


### PR DESCRIPTION
In delete_redirect_and_filter_rules() found a typo error

in update_portmapping() we have to update snat rules
and it is reasonable to ignore the failure if no snat rule found