### PR TITLE
Use LDFLAGS env var

### DIFF
--- a/miniupnpd/Makefile.bsd
+++ b/miniupnpd/Makefile.bsd
@@ -122,7 +122,7 @@ LIBS = -lkvm
 LIBS += -lsocket -lnsl -lkstat -lresolv
 .endif
 
-LIBS += -lssl -lcrypto
+LIBS += $(LDFLAGS) -lssl -lcrypto
 
 # set PREFIX variable to install in the wanted place
 


### PR DESCRIPTION
When setting LIBS variable, add LDFLAGS content to it.  It's being used on FreeBSD ports for a long time now