### PR TITLE
Fix Windows UWP build.

### DIFF
--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -32,6 +32,12 @@ typedef unsigned short uint16_t;
 #define strncasecmp memicmp
 #endif /* defined(_MSC_VER) && (_MSC_VER >= 1400) */
 #endif /* #ifndef strncasecmp */
+#if defined(WINAPI_FAMILY) && defined(WINAPI_FAMILY_PARTITION)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP
+#define in6addr_any in6addr_any_init
+static const IN6_ADDR in6addr_any_init = {0};
+#endif
+#endif
 #endif /* _WIN32 */
 #if defined(__amigaos__) || defined(__amigaos4__)
 #include <sys/socket.h>
@@ -922,4 +928,3 @@ error:
 	closesocket(sudp);
 	return devlist;
 }
-


### PR DESCRIPTION
Horrifying hack to get it linking on Windows UWP.

Seems the declaration of `in6addr_any` exists in Windows UWP headers but not the definition so it fails to link. So I substitute with an equivalent definition.