### PR TITLE
miniupnpc: Fix usage of Windows _snprintf() function

### DIFF
--- a/miniupnpc/connecthostport.c
+++ b/miniupnpc/connecthostport.c
@@ -19,7 +19,11 @@
 #include <ws2tcpip.h>
 #include <io.h>
 #define MAXHOSTNAMELEN 64
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #define herror
 #define socklen_t int
 #else /* #ifdef _WIN32 */

--- a/miniupnpc/minisoap.c
+++ b/miniupnpc/minisoap.c
@@ -13,7 +13,11 @@
 #ifdef _WIN32
 #include <io.h>
 #include <winsock2.h>
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #else
 #include <unistd.h>
 #include <sys/types.h>

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -20,7 +20,11 @@
 #include <ws2tcpip.h>
 #include <io.h>
 #include <iphlpapi.h>
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #if !defined(_MSC_VER)
 #include <stdint.h>
 #else /* !defined(_MSC_VER) */

--- a/miniupnpc/miniupnpc.c
+++ b/miniupnpc/miniupnpc.c
@@ -15,7 +15,11 @@
 #include <ws2tcpip.h>
 #include <io.h>
 #include <iphlpapi.h>
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #define strdup _strdup
 #if !defined(_MSC_VER)
 #include <stdint.h>

--- a/miniupnpc/miniwget.c
+++ b/miniupnpc/miniwget.c
@@ -15,7 +15,11 @@
 #include <ws2tcpip.h>
 #include <io.h>
 #define MAXHOSTNAMELEN 64
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #define socklen_t int
 #ifndef strncasecmp
 #if defined(_MSC_VER) && (_MSC_VER >= 1400)

--- a/miniupnpc/setupmingw32.py
+++ b/miniupnpc/setupmingw32.py
@@ -30,6 +30,6 @@ setup(name="miniupnpc",
       ext_modules=[
          Extension(name="miniupnpc", sources=["miniupnpcmodule.c"],
                    libraries=["ws2_32", "iphlpapi"] + compat_lib,
-                   extra_objects=["libminiupnpc.a"])
+                   extra_objects=["miniupnpc.lib"])
       ])
 

--- a/miniupnpc/upnpc.c
+++ b/miniupnpc/upnpc.c
@@ -11,7 +11,11 @@
 #include <time.h>
 #ifdef _WIN32
 #include <winsock2.h>
-#define snprintf _snprintf
+/* snprintf is supported by Visual Studio 2015, mingw-w64 8.0.0, mingw-w64 with ucrt, mingw-w64 or mingw32 with ansi stdio */
+#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR < 8 && !defined(_UCRT) && !defined(__USE_MINGW_ANSI_STDIO)) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && !defined(__USE_MINGW_ANSI_STDIO))
+/* _snprintf does not fill nul byte at the end of buffer and returns -1 on overflow */
+#define snprintf(buf, size, fmt, ...) ((_snprintf((buf), (size), (fmt), __VA_ARGS__), (((char *)buf)[(size_t)(size)-1] = 0), _scprintf((fmt), __VA_ARGS__)))
+#endif
 #else
 /* for IPPROTO_TCP / IPPROTO_UDP */
 #include <netinet/in.h>


### PR DESCRIPTION
_snprintf() differs from snprintf() in:

* on overflow it returns -1 instead of required buffer size
* on overflow it does not fill nul byte
* does not accept NULL/0 as a buffer

Microsoft implemented snprintf() in Visual Studio 2015 as part of UCRT.

Mingw32 contains snprintf() implementation only when __USE_MINGW_ANSI_STDIO
is defined.

Mingw-w64 versions prior to 8.0.0. contain snprintf() implementation when
__USE_MINGW_ANSI_STDIO or _UCRT is defined. Since version 8.0.0 it is
always supported.

Mingw-w64 defines both __MINGW32__ and __MINGW64_VERSION_MAJOR macros.
Mingw32 defines only __MINGW32__.

_scprintf() just count number of bytes needed for formatting string, so it
is basically return value of snprintf().

This change updates miniupnpc code to use snprintf() when is provided by
compiler/runtime to avoid usage _snprintf().

And also this changes updates miniupnpc emulation of snprintf() by
_snprintf() and _scprintf() functions to avoid buffer overflows.

For inspiration full emulation of snprintf() by _snprintf() is available in
mingw-w64 stdio library:

https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/stdio/snprintf.c