### PR TITLE
fix portinuse.c for OpenBSD 5.5+

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -1,4 +1,7 @@
-$Id: Changelog.txt,v 1.467 2020/06/20 15:45:30 nanard Exp $
+$Id: Changelog.txt,v 1.469 2020/10/30 21:11:50 nanard Exp $
+
+2020/10/30:
+  OpenBSD: portinuse.c compatible with OpenBSD 5.5+
 
 2020/10/22:
   netfilter_nft: fix rule-cache update when using the same chain name in

--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -1,5 +1,5 @@
 #! /bin/sh
-# $Id: configure,v 1.111 2020/05/10 22:26:13 nanard Exp $
+# $Id: configure,v 1.113 2020/10/30 21:11:52 nanard Exp $
 # vim: tabstop=4 shiftwidth=4 noexpandtab
 #
 # miniupnp daemon
@@ -199,6 +199,10 @@ case $OS_NAME in
 		# onrdomain was introduced in OpenBSD 5.0
 		if [ $MAJORVER -ge 5 ]; then
 			echo "#define PFRULE_HAS_ONRDOMAIN" >> ${CONFIGFILE}
+		fi
+		# before OpenBSD 5.5 inpt_queue was CIRCLEQ
+		if [ $MAJORVER -lt 5 ] || [ $MAJORVER -eq 5 -a $MINORVER -lt 5 ]; then
+			echo "#define INPT_QUEUE_IS_CIRCLEQ" >> ${CONFIGFILE}
 		fi
 		FW=pf
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}


### PR DESCRIPTION
all CIRCLEQ have been replaced by TAILQ
fixes #496