### PR TITLE
docs: fix simple typo, decription -> description

### DIFF
--- a/miniupnpd/commonrdr.h
+++ b/miniupnpd/commonrdr.h
@@ -57,13 +57,13 @@ unsigned short *
 get_portmappings_in_range(unsigned short startport, unsigned short endport,
                           int proto, unsigned int * number);
 
-/* update the port mapping internal port, decription and timestamp */
+/* update the port mapping internal port, description and timestamp */
 int
 update_portmapping(const char * ifname, unsigned short eport, int proto,
                    unsigned short iport, const char * desc,
                    unsigned int timestamp);
 
-/* update the port mapping decription and timestamp */
+/* update the port mapping description and timestamp */
 int
 update_portmapping_desc_timestamp(const char * ifname,
                    unsigned short eport, int proto,

--- a/miniupnpd/ipf/ipfrdr.c
+++ b/miniupnpd/ipf/ipfrdr.c
@@ -804,7 +804,7 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 	return array;
 }
 
-/* update the port mapping internal port, decription and timestamp */
+/* update the port mapping internal port, description and timestamp */
 int
 update_portmapping(const char * ifname, unsigned short eport, int proto,
                    unsigned short iport, const char * desc,
@@ -817,7 +817,7 @@ update_portmapping(const char * ifname, unsigned short eport, int proto,
 	return -1;
 }
 
-/* update the port mapping decription and timestamp */
+/* update the port mapping description and timestamp */
 int
 update_portmapping_desc_timestamp(const char * ifname,
                    unsigned short eport, int proto,

--- a/miniupnpd/pf/obsdrdr.c
+++ b/miniupnpd/pf/obsdrdr.c
@@ -1379,7 +1379,7 @@ get_portmappings_in_range(unsigned short startport, unsigned short endport,
 	return array;
 }
 
-/* update the port mapping internal port, decription and timestamp */
+/* update the port mapping internal port, description and timestamp */
 int
 update_portmapping(const char * ifname, unsigned short eport, int proto,
                    unsigned short iport, const char * desc,
@@ -1406,7 +1406,7 @@ update_portmapping(const char * ifname, unsigned short eport, int proto,
 	return 0;
 }
 
-/* update the port mapping decription and timestamp */
+/* update the port mapping description and timestamp */
 int
 update_portmapping_desc_timestamp(const char * ifname,
                    unsigned short eport, int proto,


### PR DESCRIPTION
There is a small typo in miniupnpd/commonrdr.h, miniupnpd/ipf/ipfrdr.c, miniupnpd/pf/obsdrdr.c.

Should read `description` rather than `decription`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md