### PR TITLE
Fallback for earlier Apple platforms that lack clock_gettime

### DIFF
--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -463,14 +463,29 @@ static int upnp_gettimeofday(struct timeval * tv)
 	tv->tv_usec = (ts % 1000) * 1000;
 	return 0; /* success */
 #elif defined(CLOCK_MONOTONIC_FAST) || defined(CLOCK_MONOTONIC)
-	struct timespec ts;
-	int ret_code = clock_gettime(UPNP_CLOCKID, &ts);
-	if (ret_code == 0)
-	{
-		tv->tv_sec = ts.tv_sec;
-		tv->tv_usec = ts.tv_nsec / 1000;
+#if defined(__APPLE__)
+#if defined(__clang__)
+	if (__builtin_available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)) {
+#else // !defined(__clang__)
+	if (clock_gettime != NULL) {
+#endif // defined(__clang__)
+#endif // defined(__APPLE__)
+		struct timespec ts;
+		int ret_code = clock_gettime(UPNP_CLOCKID, &ts);
+		if (ret_code == 0)
+		{
+			tv->tv_sec = ts.tv_sec;
+			tv->tv_usec = ts.tv_nsec / 1000;
+		}
+		return ret_code;
+#if defined(__APPLE__)
 	}
-	return ret_code;
+	else
+	{
+		// fall-back for earlier Apple platforms
+		return gettimeofday(tv, NULL);
+	}
+#endif // defined(__APPLE__)
 #else
 	return gettimeofday(tv, NULL);
 #endif


### PR DESCRIPTION
`clock_gettime` is only available on macOS >= 10.12, iOS >= 10.0 (etc).

Support compiling with a MACOSX_DEPLOYMENT_TARGET < 10.12 by using `__builtin_available` to detect when running on an earlier system, and fall-back to `gettimeofday` when `clock_gettime` is not available.