### PR TITLE
miniupnpc: Fix usage of IP_MULTICAST_IF with struct ip_mreqn

### DIFF
--- a/miniupnpc/addr_is_reserved.c
+++ b/miniupnpc/addr_is_reserved.c
@@ -62,7 +62,7 @@ int addr_is_reserved(const char * addr_str)
 		return 1;
 #else
 	/* was : addr_n = inet_addr(addr_str); */
-	if (inet_pton(AF_INET, addr_str, &addr_n) < 0) {
+	if (inet_pton(AF_INET, addr_str, &addr_n) <= 0) {
 		/* error */
 		return 1;
 	}

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -697,6 +697,13 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 			 * MS Windows Vista and MS Windows Server 2008.
 			 * http://msdn.microsoft.com/en-us/library/bb408409%28v=vs.85%29.aspx */
 			unsigned int ifindex = if_nametoindex(multicastif); /* eth0, etc. */
+			if(ifindex == 0)
+			{
+				if(error)
+					*error = MINISSDPC_INVALID_INPUT;
+				fprintf(stderr, "Invalid multicast interface name %s\n", multicastif);
+				goto error;
+			}
 			if(setsockopt(sudp, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) < 0)
 			{
 				PRINT_SOCKET_ERROR("setsockopt IPV6_MULTICAST_IF");
@@ -733,6 +740,13 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 				struct ip_mreqn reqn;	/* only defined with -D_BSD_SOURCE or -D_GNU_SOURCE */
 				memset(&reqn, 0, sizeof(struct ip_mreqn));
 				reqn.imr_ifindex = if_nametoindex(multicastif);
+				if(reqn.imr_ifindex == 0)
+				{
+					if(error)
+						*error = MINISSDPC_INVALID_INPUT;
+					fprintf(stderr, "Invalid multicast ip address / interface name %s\n", multicastif);
+					goto error;
+				}
 				if(setsockopt(sudp, IPPROTO_IP, IP_MULTICAST_IF, (const char *)&reqn, sizeof(reqn)) < 0)
 				{
 					PRINT_SOCKET_ERROR("setsockopt IP_MULTICAST_IF");

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -716,7 +716,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 #endif
 #else
 			/* was : mc_if.s_addr = inet_addr(multicastif); */ /* ex: 192.168.x.x */
-			if (inet_pton(AF_INET, multicastif, &mc_if.s_addr) < 0) {
+			if (inet_pton(AF_INET, multicastif, &mc_if.s_addr) <= 0) {
 				mc_if.s_addr = INADDR_NONE;
 			}
 #endif


### PR DESCRIPTION
When struct ip_mreqn is passed to IP_MULTICAST_IF setsockopt option it is
always required to set also ipv4 source address. Otherwise Linux kernel
will choose default system multicast ipv4 address which does not have to
belong to chosen interface specified in struct ip_mreqn.

Therefore on system with more multicast interfaces and more ipv4 addresses,
it may happen that interface chosen by upnpc -m option would use ipv4
address which does not belong to this interface.

This change is fixing above issue and ensure that if interface is chosen by
upnpc -m option then source address which belongs to this interface would
be used.

Without this change upnpc -m eth1 can send multicast traffic over interface
eth1 but with source ipv4 address of interface eth0, which obviously would
be rejected by upnp gateway.