### PR TITLE
Fix incorrect addition of jump rule to PREROUTING mangle chain

### DIFF
--- a/miniupnpd/netfilter/iptables_init.sh
+++ b/miniupnpd/netfilter/iptables_init.sh
@@ -32,11 +32,11 @@ if [ "$MDIRTY" = "${CHAIN}Chain" ]; then
 	echo "Mangle table dirty; Cleaning..."
 elif [ "$MDIRTY" = "Chain" ]; then
 	echo "Dirty Mangle chain but no reference..? Fixing..."
-	$IPTABLES -t mangle $ADDCMD PREROUTING -i $EXTIF -j $CHAIN
+	$IPTABLES -t mangle $ADDCMD FORWARD -i $EXTIF -j $CHAIN
 else
 	echo "Mangle table clean..initializing..."
 	$IPTABLES -t mangle -N $CHAIN
-	$IPTABLES -t mangle $ADDCMD PREROUTING -i $EXTIF -j $CHAIN
+	$IPTABLES -t mangle $ADDCMD FORWARD -i $EXTIF -j $CHAIN
 fi
 if [ "$CLEAN" = "yes" ]; then
 	$IPTABLES -t mangle -F $CHAIN


### PR DESCRIPTION
In the current iptables init script, the mangle table has a rule added to jump to the MINIUPNPD chain in the mangle table added to PREROUTING. However, if you look at `iptables_removeall.sh`, it tries to remove the rule from the `FORWARD` chain instead (see the line [here](https://github.com/miniupnp/miniupnp/blob/bfc5eab6be38d693d0fa8bfecc467021c0c85c1f/miniupnpd/netfilter/iptables_removeall.sh#L21). This changes the init script to add the jump rule to the FORWARD chain instead of the PREROUTING chain.

When this is not done, the mangle table is not properly reset on calling the `iptables_removeall.sh` script. Specifically the rule jumping to MINIUPNPD and the MINIUPNPD chain itself remain (though rules are correctly flushed). Additionally, there is an error message in the logs as follows:

```
REDACTED iptables_removeall.sh[1850]: iptables: No chain/target/match by that name.
REDACTED iptables_removeall.sh[1851]: iptables: Too many links.
```

To be frank, I am not certain that the intended chain to add the jump rule to is the FORWARD chain. The mistake might be in `iptables_removeall.sh` in trying to remove the rule from the `FORWARD` chain. However, to the best I can understand, the mangle table is used to adjust the DSCP of incoming packets (though to be clear, I don't understand when and why this is done in the UPnP protocol), and by looking at other examples online, it seems like the FORWARD chain on the mangle table is the most common place to adjust DSCP values. Additionally, the git blame for the line in `iptables_removeall.sh` shows that the FORWARD chain was used first (`iptables_removeall.sh` was edited nine years ago to add the removal rule, while `iptables_init.sh` was added two years ago). All of this leads me to believe that the correct chain is the FORWARD chain.