### PR TITLE
Fix UWP builds after mingw changes

### DIFF
--- a/miniupnpc/addr_is_reserved.c
+++ b/miniupnpc/addr_is_reserved.c
@@ -56,7 +56,7 @@ int addr_is_reserved(const char * addr_str)
 	uint32_t addr_n, address;
 	size_t i;
 
-#if defined(_WIN32) && (!defined(_WIN32_WINNT_VISTA) || (_WIN32_WINNT < _WIN32_WINNT_VISTA))
+#if defined(_WIN32) && _WIN32_WINNT < 0x0600 // _WIN32_WINNT_VISTA
 	addr_n = inet_addr(addr_str);
 	if (addr_n == INADDR_NONE)
 		return 1;

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -576,7 +576,17 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
  * in order to give this ip to setsockopt(sudp, IPPROTO_IP, IP_MULTICAST_IF) */
 	if(!ipv6) {
 		DWORD ifbestidx;
+#if _WIN32_WINNT >= 0x0600 // _WIN32_WINNT_VISTA
+		// While we don't need IPv6 support, the IPv4 only funciton is not available in UWP apps.
+		SOCKADDR_IN destAddr;
+		memset(&destAddr, 0, sizeof(destAddr));
+		destAddr.sin_family = AF_INET;
+		destAddr.sin_addr.s_addr = inet_addr("223.255.255.255");
+		destAddr.sin_port = 0;
+		if (GetBestInterfaceEx((struct sockaddr *)&destAddr, &ifbestidx) == NO_ERROR) {
+#else
 		if (GetBestInterface(inet_addr("223.255.255.255"), &ifbestidx) == NO_ERROR) {
+#endif
 			DWORD dwRetVal = NO_ERROR;
 			PIP_ADAPTER_ADDRESSES pAddresses = NULL;
 			ULONG outBufLen = 15360;

--- a/miniupnpc/minissdpc.c
+++ b/miniupnpc/minissdpc.c
@@ -460,7 +460,7 @@ parseMSEARCHReply(const char * reply, int size,
 static int upnp_gettimeofday(struct timeval * tv)
 {
 #if defined(_WIN32)
-#if defined(_WIN32_WINNT_VISTA) && (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#if _WIN32_WINNT >= 0x0600 // _WIN32_WINNT_VISTA
 	ULONGLONG ts = GetTickCount64();
 #else
 	DWORD ts = GetTickCount();
@@ -722,7 +722,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 		} else {
 			struct in_addr mc_if;
 #if defined(_WIN32)
-#if defined(_WIN32_WINNT_VISTA) && (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#if _WIN32_WINNT >= 0x0600 // _WIN32_WINNT_VISTA
 			InetPtonA(AF_INET, multicastif, &mc_if);
 #else
 			mc_if.s_addr = inet_addr(multicastif); /* old Windows SDK do not support InetPtoA() */


### PR DESCRIPTION
Since #499, `GetBestInterface` is used instead of `GetBestInterfaceEx` for compatibility with old mingw verisons (and because IPv6 is indeed not needed), but microsoft decided for no apparent reason beside pure lobbying not to include the IPv4-only version `GetBestInterface` in the UWP libraries.

This PR reintroduces the use of `GetBestInterfaceEx` while trying to keep compatibility with old mingw by checking the `_WIN32_WINNT`, which I've also switched to use the [well known code](https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-160) instead of `_WIN32_WINNT_VISTA` which might not be defined.