### PR TITLE
IGD v2.0: Unknown ExternalIPAddress is represented as empty string

### DIFF
--- a/miniupnpc/upnpc.c
+++ b/miniupnpc/upnpc.c
@@ -111,6 +111,8 @@ static void DisplayInfos(struct UPNPUrls * urls,
 							  externalIPAddress);
 	if(r != UPNPCOMMAND_SUCCESS) {
 		printf("GetExternalIPAddress failed. (errorcode=%d)\n", r);
+	} else if(!externalIPAddress[0]) {
+		printf("GetExternalIPAddress failed. (empty string)\n");
 	} else {
 		printf("ExternalIPAddress = %s\n", externalIPAddress);
 	}

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -365,10 +365,7 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
 	}
 #endif
 	if (strcmp(ext_ip_addr, "0.0.0.0") == 0)
-	{
-		SoapError(h, 501, "Action Failed");
-		return;
-	}
+		ext_ip_addr[0] = '\0';
 	bodylen = snprintf(body, sizeof(body), resp,
 	              action, ns, /*SERVICE_TYPE_WANIPC,*/
 				  ext_ip_addr, action);


### PR DESCRIPTION
IGD v2.0 specification for WANIPConnection:2 says:
    
When the external IP address could not be retrieved by the gateway (for
example, because the interface is down or because there was a failure in
the last connection setup attempt), then the ExternalIPAddress MUST be
equal to the empty string.