### PR TITLE
Reproducible Builds: Do not embed build system kernel version in binary

### DIFF
--- a/miniupnpc/updateminiupnpcstrings.sh
+++ b/miniupnpc/updateminiupnpcstrings.sh
@@ -9,7 +9,7 @@ TEMPLATE_FILE=${FILE}.in
 
 # detecting the OS name and version
 OS_NAME=`uname -s`
-OS_VERSION=`uname -r`
+OS_VERSION='unknown'
 if [ -f /etc/debian_version ]; then
 	OS_NAME=Debian
 	OS_VERSION=`cat /etc/debian_version`

--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -89,7 +89,7 @@ LOG_MINIUPNPD="LOG_DAEMON"
 
 # detecting the OS name and version
 OS_NAME=`uname -s`
-OS_VERSION=`uname -r`
+OS_VERSION='unknown'
 OS_MACHINE=`uname -m`
 # Makefile to use
 MAKEFILE=
@@ -364,7 +364,7 @@ case $OS_NAME in
 					;;
 				arch)
 					OS_URL=http://www.archlinux.org/
-					OS_VERSION=`uname -r`
+					OS_VERSION='rolling'
 					;;
 			esac
 		fi


### PR DESCRIPTION
Our [Reproducible Builds system at Arch Linux](https://reproducible.archlinux.org/) has flagged reproducible builds issues in software using miniupnp. Embedding the kernel version in the binary is causing reproducible builds issues:
```
│ │ │ -User-Agent: Linux/5.7.9-arch1-1, UPnP/1.1, MiniUPnPc/2.0
│ │ │ +User-Agent: Linux/5.11.16-arch1-1, UPnP/1.1, MiniUPnPc/2.0
```
If you insist on using the kernel version I'd recommend to run `uname` at runtime because that's likely the value you're actually interested in.

Related to https://github.com/transmission/transmission/issues/1696