### PR TITLE
[CMake] Only include listdevices.c as part of the listdevices executable

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -69,7 +69,6 @@ set (MINIUPNPC_SOURCES
   connecthostport.c
   portlistingparse.c
   receivedata.c
-  listdevices.c
 	addr_is_reserved.c
   connecthostport.h
   igd_desc_parse.h


### PR DESCRIPTION
Currently, `listdevices.c` is included in `MINIUPNPC_SOURCES`, and thus it is included / built as part of the `libminiupnpc-static` & `libminiupnpc-shared` library targets.

This can cause issues with certain build systems / targets. (I.e. Potentially overriding `main` for an executable that links to `libminiupnpc-static`, depending on a number of factors.)

@miniupnp