### PR TITLE
Fix `__STDC_VERSION__` check in upnpdev.h

### DIFF
--- a/miniupnpc/upnpdev.h
+++ b/miniupnpc/upnpdev.h
@@ -20,7 +20,7 @@ struct UPNPDev {
 	char * st;
 	char * usn;
 	unsigned int scope_id;
-#if defined(__STDC_VERSION) && __STDC_VERSION__ >= 199901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 	/* C99 flexible array member */
 	char buffer[];
 #elif defined(__GNUC__)


### PR DESCRIPTION
Note that `__STDC_VERSION__` version checks are currently performed 3 different ways in this codebase. Not sure if you want to consolidate how they are done? The other two being:

https://github.com/miniupnp/miniupnp/blob/7783ac1545f70e3341da5866069bde88244dd848/miniupnpc/miniupnpctypes.h#L10

https://github.com/miniupnp/miniupnp/blob/2254e8928e658e7f65418bec1efcaa055946f123/miniupnpd/netfilter_nft/nftnlrdr_misc.c#L52