### PR TITLE
miniupnpd: improve error message for bad config

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1817,6 +1817,10 @@ init(int argc, char * * argv, struct runtime_vars * v)
 	}
 	if(!ext_if_name || !lan_addrs.lh_first) {
 		/* bad configuration */
+		if(!ext_if_name)
+		    INIT_PRINT_ERR(stderr, "Error: Option -i missing and ext_ifname is not set in config file\n");
+		if (!lan_addrs.lh_first)
+		    INIT_PRINT_ERR(stderr, "Error: Option -a missing and listening_ip is not set in config file\n");
 		goto print_usage;
 	}
 


### PR DESCRIPTION
Improve error message so users don't need read the source to figure out
why miniupnpd refuses to start even if the usage is correct.