### PR TITLE
CMake: fix cross-build to iOS/tvOS/watchOS

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -29,7 +29,7 @@ if (NOT WIN32)
   target_compile_definitions(miniupnpc-private INTERFACE
     MINIUPNPC_SET_SOCKET_TIMEOUT
     _BSD_SOURCE _DEFAULT_SOURCE)
-  if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" AND NOT CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+  if (NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" AND NOT CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     # add_definitions (-D_POSIX_C_SOURCE=200112L)
     target_compile_definitions(miniupnpc-private INTERFACE _XOPEN_SOURCE=600)
   endif ()
@@ -37,7 +37,7 @@ else ()
   target_compile_definitions(miniupnpc-private INTERFACE _WIN32_WINNT=0x0501) # XP or higher for getnameinfo and friends
 endif ()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if (APPLE)
   target_compile_definitions(miniupnpc-private INTERFACE _DARWIN_C_SOURCE)
 endif ()
 


### PR DESCRIPTION
Cross-compilation of miniupnpc to iOS/tvOS/watchOS fails:

<details><summary>Compilation errors</summary>

```
[5/16] Building C object source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/minissdpc.c.o
FAILED: source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/minissdpc.c.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNP_STATICLIB -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -Isource_subfolder/miniupnpc -O3 -DNDEBUG  -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.2.sdk -miphoneos-version-min=12.0 -fPIC -MD -MT source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/minissdpc.c.o -MF source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/minissdpc.c.o.d -o source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/minissdpc.c.o -c source_subfolder/miniupnpc/minissdpc.c
source_subfolder/miniupnpc/minissdpc.c:690:35: error: use of undeclared identifier 'IP_MULTICAST_TTL'
                if(setsockopt(sudp, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
                                                ^
source_subfolder/miniupnpc/minissdpc.c:733:20: error: use of undeclared identifier 'INADDR_NONE'
                                mc_if.s_addr = INADDR_NONE;
                                               ^
source_subfolder/miniupnpc/minissdpc.c:736:23: error: use of undeclared identifier 'INADDR_NONE'
                        if(mc_if.s_addr != INADDR_NONE)
                                           ^
source_subfolder/miniupnpc/minissdpc.c:739:37: error: use of undeclared identifier 'IP_MULTICAST_IF'
                                if(setsockopt(sudp, IPPROTO_IP, IP_MULTICAST_IF, (const char *)&mc_if, sizeof(mc_if)) < 0)
                                                                ^
source_subfolder/miniupnpc/minissdpc.c:749:18: error: variable has incomplete type 'struct ifreq'
                                struct ifreq ifr;
                                             ^
source_subfolder/miniupnpc/minissdpc.c:749:12: note: forward declaration of 'struct ifreq'
                                struct ifreq ifr;
                                       ^
source_subfolder/miniupnpc/minissdpc.c:751:40: error: use of undeclared identifier 'IFNAMSIZ'
                                strncpy(ifr.ifr_name, multicastif, IFNAMSIZ);
                                                                   ^
source_subfolder/miniupnpc/minissdpc.c:752:18: error: use of undeclared identifier 'IFNAMSIZ'
                                ifr.ifr_name[IFNAMSIZ-1] = '\0';
                                             ^
source_subfolder/miniupnpc/minissdpc.c:753:20: error: invalid application of 'sizeof' to an incomplete type 'struct ifreq'
                                if(ioctl(sudp, SIOCGIFADDR, &ifr, &ifrlen) < 0)
                                               ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.2.sdk/usr/include/sys/sockio.h:94:25: note: expanded from macro 'SIOCGIFADDR'
#define SIOCGIFADDR     _IOWR('i', 33, struct ifreq)    /* get ifnet address */
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.2.sdk/usr/include/sys/ioccom.h:97:53: note: expanded from macro '_IOWR'
#define _IOWR(g, n, t)    _IOC(IOC_INOUT,       (g), (n), sizeof(t))
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.2.sdk/usr/include/sys/ioccom.h:92:13: note: expanded from macro '_IOC'
        (inout | ((len & IOCPARM_MASK) << 16) | ((group) << 8) | (num))
                   ^~~
source_subfolder/miniupnpc/minissdpc.c:749:12: note: forward declaration of 'struct ifreq'
                                struct ifreq ifr;
                                       ^
source_subfolder/miniupnpc/minissdpc.c:775:37: error: use of undeclared identifier 'IP_MULTICAST_IF'
                                if(setsockopt(sudp, IPPROTO_IP, IP_MULTICAST_IF, (const char *)&mc_if, sizeof(mc_if)) < 0)
                                                                ^
9 errors generated.
[15/16] Building C object source_subfolder/miniupnpc/CMakeFiles/libminiupnpc-static.dir/miniwget.c.o
ninja: build stopped: subcommand failed.
```

</details>

`CMAKE_SYSTEM_NAME` is not `Darwin` for these hosts. I could repeat `CMAKE_SYSTEM_NAME` for all these OS, but `APPLE` variable avoids boilerplate.