### PR TITLE
miniupnpd: Disable port forwarding when upstream interface is down

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -2239,6 +2239,7 @@ main(int argc, char * * argv)
 		struct in_addr addr;
 		if (getifaddr(ext_if_name, if_addr, INET_ADDRSTRLEN, &addr, NULL) < 0) {
 			syslog(LOG_WARNING, "Cannot get IP address for ext interface %s. Network is down", ext_if_name);
+			disable_port_forwarding = 1;
 		} else if (addr_is_reserved(&addr)) {
 			syslog(LOG_INFO, "Reserved / private IP address %s on ext interface %s: Port forwarding is impossible", if_addr, ext_if_name);
 			syslog(LOG_INFO, "You are probably behind NAT, enable option ext_perform_stun=yes to detect public IP address");


### PR DESCRIPTION
Obviously port forwarding cannot work when upstream interface is down. So
correctly report status code for port forwarding requests to clients in
this case.