### PR TITLE
Extend GitHub workflows for Windows

### DIFF
--- a/.github/workflows/i586-mingw32msvc.yml
+++ b/.github/workflows/i586-mingw32msvc.yml
@@ -1,0 +1,25 @@
+name: i586-mingw32msvc
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: download packages
+        run: wget -c https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-binutils_2.20-0.2ubuntu1_amd64.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-runtime_3.15.2-0ubuntu1_all.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32_4.2.1.dfsg-2ubuntu1_amd64.deb
+
+      - name: install packages
+        run: sudo dpkg -i mingw32-binutils_2.20-0.2ubuntu1_amd64.deb mingw32-runtime_3.15.2-0ubuntu1_all.deb mingw32_4.2.1.dfsg-2ubuntu1_amd64.deb
+
+      - name: check for correct compiler target
+        run: "i586-mingw32msvc-gcc -v 2>&1 | grep -q -x 'Target: i586-mingw32msvc'"
+
+      - name: build miniupnpc via i586-mingw32msvc
+        run: make -C miniupnpc -f Makefile.mingw CC=i586-mingw32msvc-gcc DLLWRAP=i586-mingw32msvc-dllwrap WINDRES=i586-mingw32msvc-windres AR=i586-mingw32msvc-ar

--- a/.github/workflows/i686-w64-mingw32.yml
+++ b/.github/workflows/i686-w64-mingw32.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: mingw
+name: i686-w64-mingw32
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -25,7 +25,7 @@ jobs:
       - name: install packages
         run: sudo apt-get install gcc-mingw-w64-i686 mingw-w64-tools
 
-      - name: build miniupnpc for win32
+      - name: build miniupnpc via i686-w64-mingw32
         run: make -C miniupnpc -f Makefile.mingw DLLWRAP=i686-w64-mingw32-dllwrap CC=i686-w64-mingw32-gcc WINDRES=i686-w64-mingw32-windres AR=i686-w64-mingw32-ar all dist
 
       - name: upload binaries

--- a/.github/workflows/x86_64-w64-mingw32.yml
+++ b/.github/workflows/x86_64-w64-mingw32.yml
@@ -1,0 +1,32 @@
+name: x86_64-w64-mingw32
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install packages
+        run: sudo apt-get install gcc-mingw-w64-x86-64 mingw-w64-tools
+
+      - name: build miniupnpc via x86_64-w64-mingw32
+        run: make -C miniupnpc -f Makefile.mingw DLLWRAP=x86_64-w64-mingw32-dllwrap CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres AR=x86_64-w64-mingw32-ar all dist
+
+      - name: upload binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: miniupnpc-win64-binaries-${{github.sha}}
+          path: |
+            miniupnpc/*.exe
+            miniupnpc/*.dll
+            miniupnpc/*.def
+            miniupnpc/*.a
+            miniupnpc/LICENSE
+            miniupnpc/README
+            miniupnpc/Changelog.txt


### PR DESCRIPTION
Add support for i586-mingw32msvc and x86_64-w64-mingw32 cross-compilers into Github CI like it was in old Travis CI.