### PR TITLE
NFTables use inet nat chain

### DIFF
--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -84,29 +84,12 @@ init_redirect(void)
 						  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER - 25);
 	}
 
-	/* 'ip' family */
 	if (result == 0) {
-		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV4, nft_table);
-	}
-	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_INET, nft_table,
 						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
 	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV4, nft_table,
-						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
-	}
-
-	/* 'ip6' family */
-	if (result == 0) {
-		result = table_op(NFT_MSG_NEWTABLE, NFPROTO_IPV6, nft_table);
-	}
-	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table,
-						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
-	}
-	if (result == 0) {
-		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_IPV6, nft_table,
+		result = chain_op(NFT_MSG_NEWCHAIN, NFPROTO_INET, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 
@@ -122,31 +105,15 @@ shutdown_redirect(void)
 	result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_INET, nft_table,
 					  nft_forward_chain, FILTER_CHAIN_TYPE, NF_INET_FORWARD, NF_IP_PRI_FILTER - 25);
 	if (result == 0) {
-		result = table_op(NFT_MSG_DELTABLE, NFPROTO_INET, nft_table);
-	}
-
-	/* 'ip' family */
-	result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table,
+		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_INET, nft_table,
 					  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
+	}
 	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV4, nft_table,
+		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_INET, nft_table,
 						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
 	}
 	if (result == 0) {
-		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV4, nft_table);
-	}
-
-	/* 'ip6' family */
-	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table,
-						  nft_prerouting_chain, NAT_CHAIN_TYPE, NF_INET_PRE_ROUTING, NF_IP_PRI_NAT_DST);
-	}
-	if (result == 0) {
-		result = chain_op(NFT_MSG_DELCHAIN, NFPROTO_IPV6, nft_table,
-						  nft_postrouting_chain, NAT_CHAIN_TYPE, NF_INET_POST_ROUTING, NF_IP_PRI_NAT_SRC);
-	}
-	if (result == 0) {
-		result = table_op(NFT_MSG_DELTABLE, NFPROTO_IPV6, nft_table);
+		result = table_op(NFT_MSG_DELTABLE, NFPROTO_INET, nft_table);
 	}
 
 	nft_mnl_disconnect();
@@ -256,7 +223,7 @@ add_redirect_rule2(const char * ifname,
 	d_printf(("add redirect rule2(%s, %s, %u, %s, %u, %d, %s)!\n",
 	          ifname, rhost, eport, iaddr, iport, proto, desc));
 
-	r = rule_set_dnat(NFPROTO_IPV4, ifname, proto,
+	r = rule_set_dnat(NFPROTO_INET, ifname, proto,
 	                  0, eport,
 	                  inet_addr(iaddr), iport,  desc, NULL);
 
@@ -285,7 +252,7 @@ add_peer_redirect_rule2(const char * ifname,
 
 	d_printf(("add peer redirect rule2()!\n"));
 
-	r = rule_set_snat(NFPROTO_IPV4, proto,
+	r = rule_set_snat(NFPROTO_INET, proto,
 	                  inet_addr(rhost), rport,
 	                  inet_addr(eaddr), eport,
 	                  inet_addr(iaddr), iport, desc, NULL);

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -629,7 +629,7 @@ int
 refresh_nft_cache_peer(void)
 {
 	if (rule_list_peer_validate != RULE_CACHE_VALID) {
-		if (refresh_nft_cache(&head_peer, nft_table, nft_postrouting_chain, NFPROTO_IPV4, RULE_NAT) < 0)
+		if (refresh_nft_cache(&head_peer, nft_table, nft_postrouting_chain, NFPROTO_INET, RULE_NAT) < 0)
 			return -1;
 		rule_list_peer_validate = RULE_CACHE_VALID;
 	}
@@ -640,7 +640,7 @@ int
 refresh_nft_cache_redirect(void)
 {
 	if (rule_list_redirect_validate != RULE_CACHE_VALID) {
-		if (refresh_nft_cache(&head_redirect, nft_table, nft_prerouting_chain, NFPROTO_IPV4, RULE_NAT) < 0)
+		if (refresh_nft_cache(&head_redirect, nft_table, nft_prerouting_chain, NFPROTO_INET, RULE_NAT) < 0)
 			return -1;
 		rule_list_redirect_validate = RULE_CACHE_VALID;
 	}
@@ -927,7 +927,7 @@ rule_set_snat(uint8_t family, uint8_t proto,
 		expr_add_cmp(r, NFT_REG_1, NFT_CMP_EQ, &sport, sizeof(uint16_t));
 	}
 
-	expr_add_nat(r, NFT_NAT_SNAT, family, ehost, htons(eport), 0);
+	expr_add_nat(r, NFT_NAT_SNAT, NFPROTO_IPV4, ehost, htons(eport), 0);
 
 	debug_rule(r);
 
@@ -999,7 +999,7 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 		expr_add_cmp(r, NFT_REG_1, NFT_CMP_EQ, &dport, sizeof(uint16_t));
 	}
 
-	expr_add_nat(r, NFT_NAT_DNAT, family, ihost, htons(iport), 0);
+	expr_add_nat(r, NFT_NAT_DNAT, NFPROTO_IPV4, ihost, htons(iport), 0);
 
 	debug_rule(r);
 
@@ -1158,9 +1158,15 @@ rule_del_handle(rule_t *rule)
 		return NULL;
 	}
 
+	if (rule->type == RULE_NAT) {
+		// NAT Family is not chain/rule family
+		nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, NFPROTO_INET);
+	} else {
+		nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, rule->family);
+	}
+
 	nftnl_rule_set_str(r, NFTNL_RULE_TABLE, rule->table);
 	nftnl_rule_set_str(r, NFTNL_RULE_CHAIN, rule->chain);
-	nftnl_rule_set_u32(r, NFTNL_RULE_FAMILY, rule->family);
 	nftnl_rule_set_u64(r, NFTNL_RULE_HANDLE, rule->handle);
 
 	return r;

--- a/miniupnpd/netfilter_nft/scripts/nft_delete_chain.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_delete_chain.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-nft delete chain nat MINIUPNPD
-nft delete chain nat MINIUPNPD-POSTROUTING
-nft delete chain filter MINIUPNPD
+nft delete chain miniupnpd forward
+nft delete chain miniupnpd postrouting
+nft delete chain miniupnpd prerouting

--- a/miniupnpd/netfilter_nft/scripts/nft_display.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_display.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Prerouting
-nft list chain ip nat MINIUPNPD
+nft list chain inet miniupnpd prerouting
 # Postrouting
-nft list chain ip nat MINIUPNPD-POSTROUTING
+nft list chain inet miniupnpd postrouting
 # Filter
-nft list chain inet filter MINIUPNPD
+nft list chain inet miniupnpd forward

--- a/miniupnpd/netfilter_nft/scripts/nft_flush.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_flush.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-nft flush chain ip nat MINIUPNPD
-nft flush chain ip nat MINIUPNPD-POSTROUTING
-nft flush chain inet filter MINIUPNPD
+nft flush chain inet miniupnpd prerouting
+nft flush chain inet miniupnpd postrouting
+nft flush chain inet miniupnpd filter

--- a/miniupnpd/netfilter_nft/scripts/nft_init.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_init.sh
@@ -7,17 +7,14 @@
 
 #opts="--echo"
 
-echo "create nat table"
-nft ${opts} add table nat
+echo "create table"
+nft ${opts} add table inet miniupnpd
 
-echo "create chain in nat table"
-nft ${opts} add chain nat MINIUPNPD
+echo "create NAT chain table"
+nft ${opts} add chain inet miniupnpd preouting
 
-echo "create pcp peer chain in nat table"
-nft ${opts} add chain nat MINIUPNPD-POSTROUTING
+echo "create pcp peer chain in table"
+nft ${opts} add chain inet miniupnpd postrouting
 
-echo "create filter table"
-nft ${opts} add table inet filter
-
-echo "create chain in filter table"
-nft ${opts} add chain inet filter MINIUPNPD
+echo "create filter chain in table"
+nft ${opts} add chain inet miniupnpd forward

--- a/miniupnpd/netfilter_nft/scripts/nft_removeall.sh
+++ b/miniupnpd/netfilter_nft/scripts/nft_removeall.sh
@@ -5,40 +5,31 @@
 # Do not disturb other existing structures in nftables, e.g. those created by firewalld
 #
 
-nft --check list table nat > /dev/null 2>&1
+nft --check list table inet miniupnpd > /dev/null 2>&1
 if [ $? -eq "0" ]; then
 {
-	# nat table exists, so first remove the chains we added
-	nft --check list chain nat MINIUPNPD > /dev/null 2>&1
+	# table exists, so first remove the nat chains we added
+	nft --check list chain inet miniupnpd prerouting > /dev/null 2>&1
 	if [ $? -eq "0" ]; then
-		echo "Remove chain from nat table"
-		nft delete chain nat MINIUPNPD
+		echo "Remove nat chain from miniupnpd table"
+		nft delete chain inet miniupnpd prerouting
 	fi
 
-	nft --check list chain nat MINIUPNPD-POSTROUTING > /dev/null 2>&1
+	nft --check list chain inet miniupnpd postrouting > /dev/null 2>&1
 	if [ $? -eq "0" ]; then
-		echo "Remove pcp peer chain from nat table"
-		nft delete chain nat MINIUPNPD-POSTROUTING
+		echo "Remove pcp peer chain from miniupnpd table"
+		nft delete chain inet miniupnpd postrouting
+	fi
+
+	# remove the filter chain we added
+	nft --check list chain inet miniupnpd forward > /dev/null 2>&1
+	if [ $? -eq "0" ]; then
+		echo "Remove filter chain from miniupnpd table"
+		nft delete chain inet miniupnpd forward
 	fi
 
 	# then remove the table itself
-	echo "Remove nat table"
-	nft delete table nat
-}
-fi
-
-nft --check list table inet filter > /dev/null 2>&1
-if [ $? -eq "0" ]; then
-{
-	# filter table exists, so first remove the chain we added
-	nft --check list chain inet filter MINIUPNPD > /dev/null 2>&1
-	if [ $? -eq "0" ]; then
-		echo "Remove chain from filter table"
-		nft delete chain inet filter MINIUPNPD
-	fi
-
-	# then remove the table itself
-	echo "Remove filter table"
-	nft delete table inet filter
+	echo "Remove miniupnpd table"
+	nft delete table inet miniupnpd
 }
 fi


### PR DESCRIPTION
NFTables supports inet in the nat chain as well.
Use it instead of IPv4 chain so it is consistent with the filter chain.
This also removes the need for two separate tables to manage.

This is the linked to #422 and the first commit to fix it.

Signed-off-by: Sven Auhagen <sven.auhagen@voleatech.de>