### PR TITLE
Fix testgetifaddr.sh for less common network environments

### DIFF
--- a/miniupnpd/testgetifaddr.sh
+++ b/miniupnpd/testgetifaddr.sh
@@ -12,8 +12,8 @@ case $OS in
 	*)
 	IP="`which ip`" || exit 1
 	EXTIF="`LC_ALL=C $IP -4 route | grep 'default' | sed -e 's/.*dev[[:space:]]*//' -e 's/[[:space:]].*//'`" || exit 1
-	EXTIF="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/[0-9]+:/ { print $2 }' | cut -d ":" -f 1`"
-	EXTIP="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/inet/ { print $2 }' | cut -d "/" -f 1`"
+	EXTIF="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/[0-9]+:/ { print $2; exit 0 }' | cut -d ":" -f 1`"
+	EXTIP="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/inet/ { print $2; exit 0 }' | cut -d "/" -f 1`"
 	;;
 esac
 

--- a/miniupnpd/testgetifaddr.sh
+++ b/miniupnpd/testgetifaddr.sh
@@ -12,6 +12,7 @@ case $OS in
 	*)
 	IP="`which ip`" || exit 1
 	EXTIF="`LC_ALL=C $IP -4 route | grep 'default' | sed -e 's/.*dev[[:space:]]*//' -e 's/[[:space:]].*//'`" || exit 1
+	EXTIF="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/[0-9]+:/ { print $2 }' | cut -d ":" -f 1`"
 	EXTIP="`LC_ALL=C $IP -4 addr show $EXTIF | awk '/inet/ { print $2 }' | cut -d "/" -f 1`"
 	;;
 esac


### PR DESCRIPTION
Fixes `testgetifaddr.sh` test failures in two situations:

1. when there is no default route.
2. when the tested interface has more than one IP address.