### PR TITLE
Correct potential double-free in delete_redirect_and_filter_rules

### DIFF
--- a/miniupnpd/netfilter/iptcrdr.c
+++ b/miniupnpd/netfilter/iptcrdr.c
@@ -810,6 +810,7 @@ delete_redirect_and_filter_rules(unsigned short eport, int proto)
 		if(h)
 		{
 			r = delete_rule_and_commit(index, h, miniupnpd_nat_chain, "delete_redirect_rule");
+			h = NULL;
 		}
 		if((r == 0) && (h = iptc_init("filter")))
 		{


### PR DESCRIPTION
In `miniupnpd/netfilter/iptcrdr.c`, a potential double-free exists if `delete_rule_and_commit` fails.

Notice that `delete_rule_and_commit` always frees the iptc handle its given.

Then, because of short-circuit evaluation, the `iptc_init(..)` that follows may not execute:

```c
// abbreviated
if(h)
{
    r = delete_rule_and_commit(index, h, miniupnpd_nat_chain, "delete_redirect_rule");
}
//                            ---+
//                               v
if((r == 0) && (h = iptc_init("filter")))
{
   // ...
}
if (h)
  iptc_free(h);
```

This may happen if, for example, `iptc_commit(h)` fails in `delete_rule_and_commit(*)`. I'm not currently aware of a way to make this happen, but it should be handled properly nevertheless.
