### PR TITLE
miniupnpc/CMakeLists.txt: fix install for headers

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -221,16 +221,16 @@ endif ()
 
 if (NOT UPNPC_NO_INSTALL)
   install (FILES
-    miniupnpc.h
-    miniwget.h
-    upnpcommands.h
-    igd_desc_parse.h
-    upnpreplyparse.h
-    upnperrors.h
-    upnpdev.h
-    miniupnpctypes.h
-    portlistingparse.h
-    miniupnpc_declspec.h
+    include/miniupnpc.h
+    include/miniwget.h
+    include/upnpcommands.h
+    include/igd_desc_parse.h
+    include/upnpreplyparse.h
+    include/upnperrors.h
+    include/upnpdev.h
+    include/miniupnpctypes.h
+    include/portlistingparse.h
+    include/miniupnpc_declspec.h
     DESTINATION include/miniupnpc
   )
 


### PR DESCRIPTION
Install target fails as include files have moved

```
"build/miniupnpc-2.2.3/miniupnpc.h":
  No such file or directory.
FAILED: CMakeFiles/install.util 
cd build/miniupnpc-2.2.3/.x86_64-libreelec-linux-gnu && toolchain/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```