### PR TITLE
miniupnpc/cmake: add _WINSOCK_DEPRECATED_NO_WARNINGS definition

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -49,7 +49,7 @@ endif ()
 
 # Suppress noise warnings
 if (MSVC)
-  target_compile_definitions(miniupnpc-private INTERFACE _CRT_SECURE_NO_WARNINGS)
+  target_compile_definitions(miniupnpc-private INTERFACE _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS)
 endif()
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/miniupnpcstrings.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/miniupnpcstrings.h)


### PR DESCRIPTION
As with `_CRT_SECURE_NO_WARNINGS`, this change hides some warnings:
```
[...]\miniupnp\miniupnpc\src\addr_is_reserved.c(60): warning C4996: 'inet_addr': Use inet_pton() or InetPton() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
[...]\miniupnp\miniupnpc\src\minissdpc.c(603): warning C4996: 'inet_addr': Use inet_pton() or InetPton() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
[...]\miniupnp\miniupnpc\src\minissdpc.c(753): warning C4996: 'inet_addr': Use inet_pton() or InetPton() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
```