### PR TITLE
minixml.c sync sources

### DIFF
--- a/miniupnpc-async/minixml.c
+++ b/miniupnpc-async/minixml.c
@@ -1,10 +1,11 @@
-/* $Id: minixml.c,v 1.11 2014/02/03 15:54:12 nanard Exp $ */
-/* minixml.c : the minimum size a xml parser can be ! */
+/* $Id: minixml.c,v 1.12 2017/12/12 11:17:40 nanard Exp $ */
+/* vim: tabstop=4 shiftwidth=4 noexpandtab
+ * minixml.c : the minimum size a xml parser can be ! */
 /* Project : miniupnp
  * webpage: http://miniupnp.free.fr/ or http://miniupnp.tuxfamily.org/
  * Author : Thomas Bernard
 
-Copyright (c) 2005-2014, Thomas BERNARD
+Copyright (c) 2005-2017, Thomas BERNARD
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -161,7 +162,8 @@ static void parseelt(struct xmlparser * p)
 						if (p->xml >= p->xmlend)
 							return;
 					}
-					if(memcmp(p->xml, "<![CDATA[", 9) == 0)
+					/* CDATA are at least 9 + 3 characters long : <![CDATA[ ]]> */
+					if((p->xmlend >= (p->xml + (9 + 3))) && (memcmp(p->xml, "<![CDATA[", 9) == 0))
 					{
 						/* CDATA handling */
 						p->xml += 9;

--- a/miniupnpc/src/minixml.c
+++ b/miniupnpc/src/minixml.c
@@ -1,4 +1,4 @@
-/* $Id: minixml.c,v 1.10 2012/03/05 19:42:47 nanard Exp $ */
+/* $Id: minixml.c,v 1.12 2017/12/12 11:17:40 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * minixml.c : the minimum size a xml parser can be ! */
 /* Project : miniupnp

--- a/miniupnpd/minixml.c
+++ b/miniupnpd/minixml.c
@@ -1,4 +1,4 @@
-/* $Id: minixml.c,v 1.10 2012/03/05 19:42:47 nanard Exp $ */
+/* $Id: minixml.c,v 1.12 2017/12/12 11:17:40 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * minixml.c : the minimum size a xml parser can be ! */
 /* Project : miniupnp


### PR DESCRIPTION
In the commit a0573e251817ec090a8c9f9f41b56d720c835a6c
was fixed a buffer overflow in the minixml.c but it wasn't copied to upnpc-async.
To make comparison simpler the header was also synced from miniupnpc-libevent/minixml.c


Also please note that there is other files that were copied between projects but now differs:
* minissdpd/upnputils.c
* miniupnpc-async/upnputils.c
* miniupnpd/upnputils.c

It's possible that a bug fixed in one place wasn't copied to another.