### PR TITLE
Fix uninitialized read in update_portmapping

### DIFF
--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -693,10 +693,12 @@ update_portmapping(const char * ifname, unsigned short eport, int proto,
                    unsigned int timestamp)
 {
 	char iaddr_str[INET_ADDRSTRLEN];
-	char rhost[INET_ADDRSTRLEN];
+	char *rhost;
 	int r;
 
 	d_printf(("update_portmapping()\n"));
+
+	rhost = NULL;
 
 	if (get_redirect_rule(NULL, eport, proto, iaddr_str, INET_ADDRSTRLEN, NULL, NULL, 0, rhost, INET_ADDRSTRLEN, NULL, 0, 0) < 0)
 		return -1;


### PR DESCRIPTION
None of the called functions seemed to use rhost aside from `add_filter_rule2`
which tries to read the uninitialized data in the buffer via:

```
if (rhost != NULL && strcmp(rhost, "") != 0 && strcmp(rhost, "*") != 0) {
  rhost_addr = inet_addr(rhost);
}
```

This randomly tries to parse the uninitialized memory in `rhost`.