### PR TITLE
build: add distfile to miniupnpc make clean target

### DIFF
--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -75,6 +75,7 @@ clean:
 	$(RM) *.exe
 	$(RM) miniupnpc.dll miniupnpc.lib miniupnpc.dll.def
 	$(RM) libminiupnpc.a
+	$(RM) $(DISTFILE)
 
 $(DISTFILE):	$(BINARIES)
 	$(ZIP) $@ *.exe *.dll *.lib *.def *.a LICENSE README Changelog.txt


### PR DESCRIPTION
Otherwise it'll be left over after a `make clean`.