### PR TITLE
build miniupnpc wheels in ci

### DIFF
--- a/.github/actions/activate-venv/action.yml
+++ b/.github/actions/activate-venv/action.yml
@@ -1,0 +1,31 @@
+name: "Activate virtual environment"
+description: 'Activate the a virtual environment for future steps.'
+inputs:
+  directories:
+    description: "A list of directories to attempt to activate, terminates on the first present directory.  Uses JSON format."
+    required: true
+    default: '["venv/", ".venv/"]'
+#outputs:
+#  virtual-env:
+#    description: "The VIRTUAL_ENV environment value."
+#    value:
+#  virtual-env-bin:
+#    description: "The path to the virtual environment directory containing the executables."
+#    value:
+runs:
+  using: "composite"
+  steps:
+    - name: Activate virtual environment
+      shell: sh
+      env:
+        INPUT_DIRECTORIES: ${{ inputs.directories }}
+      run: |
+        unset PYTHON
+        for V in 311 3.11 310 3.10 39 3.9 38 3.8 37 3.7 3 ""; do
+          if command -v python$V >/dev/null; then
+            PYTHON=python$V
+            break
+          fi
+        done
+        [ -n "$PYTHON" ] || (echo "Unable to find python" && exit 1)
+        $PYTHON "${GITHUB_ACTION_PATH}/activate_venv.py"

--- a/.github/actions/activate-venv/action.yml
+++ b/.github/actions/activate-venv/action.yml
@@ -1,3 +1,17 @@
+#   Copyright 2024 Chia Network Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 name: "Activate virtual environment"
 description: 'Activate the a virtual environment for future steps.'
 inputs:

--- a/.github/actions/activate-venv/activate_venv.py
+++ b/.github/actions/activate-venv/activate_venv.py
@@ -1,0 +1,33 @@
+import json
+import os
+import pathlib
+import sys
+
+directories = [
+    pathlib.Path(directory).absolute()
+    for directory in json.loads(os.environ["INPUT_DIRECTORIES"])
+]
+github_env = pathlib.Path(os.environ["GITHUB_ENV"])
+github_path = pathlib.Path(os.environ["GITHUB_PATH"])
+
+for directory in directories:
+    if directory.exists():
+        break
+
+    print(f"No environment found at: {os.fspath(directory)}")
+else:
+    print("No environment found")
+    sys.exit(1)
+
+print(f"Environment found at: {os.fspath(directory)}")
+
+if sys.platform == "win32":
+    bin_scripts_path = directory.joinpath("Scripts")
+else:
+    bin_scripts_path = directory.joinpath("bin")
+
+with github_path.open("a") as file:
+    print(os.fspath(bin_scripts_path), file=file)
+
+with github_env.open("a") as file:
+    print(f"VIRTUAL_ENV={os.fspath(directory)}", file=file)

--- a/.github/actions/activate-venv/activate_venv.py
+++ b/.github/actions/activate-venv/activate_venv.py
@@ -1,3 +1,17 @@
+#    Copyright 2024 Chia Network Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import json
 import os
 import pathlib

--- a/.github/actions/activate-venv/readme.md
+++ b/.github/actions/activate-venv/readme.md
@@ -1,0 +1,14 @@
+# Activate virtual environment
+
+Provides cross-platform activation of a Python virtual environment.
+By default it searches in `venv/` then `.venv/`.
+This is configurable via a JSON list passed to the `directories` parameter.
+
+```yaml
+- uses: Chia-Network/actions/activate-venv@main
+```
+
+```yaml
+- uses: Chia-Network/actions/activate-venv@main
+  directories: '["another_virtualenv/"]'
+```

--- a/.github/actions/activate-venv/readme.md
+++ b/.github/actions/activate-venv/readme.md
@@ -12,3 +12,5 @@ This is configurable via a JSON list passed to the `directories` parameter.
 - uses: Chia-Network/actions/activate-venv@main
   directories: '["another_virtualenv/"]'
 ```
+
+copied from https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/activate-venv

--- a/.github/actions/activate-venv/test_check_activated.py
+++ b/.github/actions/activate-venv/test_check_activated.py
@@ -1,3 +1,17 @@
+#    Copyright 2024 Chia Network Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os
 import pathlib
 import sys

--- a/.github/actions/activate-venv/test_check_activated.py
+++ b/.github/actions/activate-venv/test_check_activated.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+import sys
+
+reference = pathlib.Path(os.environ["REFERENCE_PATH"]).absolute()
+actual = pathlib.Path(sys.executable)
+expected_inside = {"true": True, "false": False}[os.environ["EXPECTED_INSIDE"]]
+
+is_inside: bool
+try:
+    actual.relative_to(reference)
+except ValueError:
+    is_inside = False
+else:
+    is_inside = True
+
+correct = expected_inside == is_inside
+
+print(f"      reference: {reference}")
+print(f"         actual: {actual}")
+print(f"expected_inside: {expected_inside}")
+print(f"      is_inside: {is_inside}")
+print(f"        correct: {'yes' if correct else 'no'}")
+
+if not correct:
+    sys.exit(1)

--- a/.github/actions/create-venv/action.yml
+++ b/.github/actions/create-venv/action.yml
@@ -1,0 +1,29 @@
+name: "Create venv"
+description: "Create a temporary venv"
+inputs:
+  python-command:
+    description: "The Python to use for creating the environment"
+    required: false
+    default: "python"
+outputs:
+  venv_path:
+    description: "The path to the virtual environment directory, not including the bin or scripts directory."
+    value: ${{ steps.create-venv.outputs.temp-venv-path }}
+  python_executable:
+    description: "The path to the Python executable in the virtual environment directory."
+    value: ${{ steps.create-venv.outputs.temp-python-executable }}
+  activate-venv-directories:
+    description: "The JSON serialized array including the path to the temporary env.  This is for use with the activate-venv action."
+    value: ${{ steps.create-venv.outputs.activate-venv-directories }}
+runs:
+  using: "composite"
+  steps:
+    - name: Create venv
+      id: create-venv
+      shell: sh
+      run: |
+        ${{ inputs.python-command }} "${GITHUB_ACTION_PATH}/create_temporary_venv.py"
+    - name: Update pip
+      shell: sh
+      run: |
+        "${{ steps.create-venv.outputs.temp-python-executable }}" -m pip install --upgrade pip

--- a/.github/actions/create-venv/action.yml
+++ b/.github/actions/create-venv/action.yml
@@ -1,3 +1,17 @@
+#   Copyright 2024 Chia Network Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 name: "Create venv"
 description: "Create a temporary venv"
 inputs:

--- a/.github/actions/create-venv/create_temporary_venv.py
+++ b/.github/actions/create-venv/create_temporary_venv.py
@@ -1,3 +1,17 @@
+#    Copyright 2024 Chia Network Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import json
 import os
 import pathlib

--- a/.github/actions/create-venv/create_temporary_venv.py
+++ b/.github/actions/create-venv/create_temporary_venv.py
@@ -1,0 +1,28 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import venv
+
+runner_temp = os.environ["RUNNER_TEMP"]
+temporary_directory = pathlib.Path(tempfile.mkdtemp(dir=runner_temp))
+github_output = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+
+python_executable: pathlib.Path
+if sys.platform == "win32":
+    python_executable = temporary_directory.joinpath("Scripts", "python.exe")
+else:
+    python_executable = temporary_directory.joinpath("bin", "python")
+
+activate_venv_directories = json.dumps([os.fspath(temporary_directory)])
+
+with github_output.open("a") as file:
+    print(f"temp-venv-path={os.fspath(temporary_directory.as_posix())}", file=file)
+    print(
+        f"temp-python-executable={os.fspath(python_executable.as_posix())}",
+        file=file,
+    )
+    print(f"activate-venv-directories={activate_venv_directories}", file=file)
+
+venv.create(env_dir=temporary_directory, with_pip=True)

--- a/.github/actions/create-venv/readme.md
+++ b/.github/actions/create-venv/readme.md
@@ -1,0 +1,13 @@
+# Create venv
+
+Creates a venv in the runner temporary path that will be removed upon completion of the job.
+This can be used in combination with the `activate-venv` action such as shown below.
+
+```yaml
+- uses: Chia-Network/actions/create-venv@main
+  id: create-venv
+
+- uses: Chia-Network/actions/activate-venv@main
+  with:
+    directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
+```

--- a/.github/actions/create-venv/readme.md
+++ b/.github/actions/create-venv/readme.md
@@ -11,3 +11,5 @@ This can be used in combination with the `activate-venv` action such as shown be
   with:
     directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
 ```
+
+copied from https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/create-venv

--- a/.github/actions/readme.md
+++ b/.github/actions/readme.md
@@ -1,0 +1,3 @@
+Actions copied from:
+- activate-venv: https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/activate-venv
+- create-venv: https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/create-venv

--- a/.github/actions/readme.md
+++ b/.github/actions/readme.md
@@ -1,3 +1,0 @@
-Actions copied from:
-- activate-venv: https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/activate-venv
-- create-venv: https://github.com/Chia-Network/actions/tree/5851777428fb98585ae9628b7dc49ed9f6487fde/create-venv

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -36,7 +36,7 @@ jobs:
             runs-on:
               arm: [macos-latest]
               intel: [macos-latest]
-            cibw-archs-macos:
+            cibw-archs:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
@@ -48,11 +48,17 @@ jobs:
             runs-on:
               arm: [ubuntu-latest]
               intel: [ubuntu-latest]
+            cibw-archs:
+              arm: aarch64
+              intel: x86_64
           - name: Windows
             matrix: windows
             emoji: 🪟
             runs-on:
               intel: [windows-latest]
+            cibw-archs:
+              arm: ARM64
+              intel: AMD64
         python:
           - major-dot-minor: '3.7'
             cibw-build: 'cp37-*'
@@ -132,7 +138,7 @@ jobs:
       - name: Build and test
         if: matrix.os.matrix != 'windows'
         env:
-          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
+          CIBW_ARCHS: ${{ matrix.os.cibw-archs[matrix.arch.matrix] }}
           CIBW_BUILD: ${{ matrix.python.cibw-build }}
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -132,7 +132,7 @@ jobs:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
 
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python.major-dot-minor }}
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -125,8 +125,8 @@ jobs:
             matrix: intel
             cibw: x86_64
         exclude:
-#          - os:  # excluding windows entirely as that is presently handled in AppVeyor
-#              matrix: windows
+          - os:  # excluding windows entirely as that is presently handled in AppVeyor
+              matrix: windows
           - os:
               matrix: windows
             arch:
@@ -186,22 +186,9 @@ jobs:
 
       - name: Build and test
         if: matrix.os.matrix != 'windows'
-#        if: matrix.os.matrix == 'macos' || ( matrix.os.matrix == 'linux' && matrix.arch.matrix == 'intel' )
         run: |
           pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
           cibuildwheel source --output-dir dist
-
-#      - name: Build and test (QEMU)
-#        if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
-#        run: |
-#          docker run --rm --platform linux/arm64 \
-#          -v ${{ github.workspace }}:/ws \
-#          --workdir=/ws \
-#          quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
-#          bash -exc ' \
-#          python${{ matrix.python.major-dot-minor }} -m pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
-#          && python${{ matrix.python.major-dot-minor }} -m cibuildwheel source --output-dir dist \
-#          '
 
       - name: Build (Windows)
         if: matrix.os.matrix == 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -90,6 +90,12 @@ jobs:
               arch: manylinux2014
               intel: manylinux2014
             matrix: '3.11'
+          - major-dot-minor: '3.12'
+            cibw-build: 'cp312-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2014
+            matrix: '3.12'
         arch:
           - name: ARM
             matrix: arm

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -37,7 +37,7 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macOS, ARM64]
+              arm: [macos-14]
               intel: [macos-latest]
             cibw-archs-macos:
               arm: arm64

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -130,6 +130,13 @@ jobs:
 
     env:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
+      CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
+      CIBW_BUILD: ${{ matrix.python.cibw-build }}
+      CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
+      CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
+      CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
+      CIBW_PRERELEASE_PYTHONS: True
+      CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
 
     steps:
       - uses: actions/setup-python@v5
@@ -151,28 +158,27 @@ jobs:
         run: |
           cp -RLv cloned/miniupnpc source
 
-      - name: Install tools
-        if: matrix.os.matrix != 'windows'
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
-
       - name: Set up QEMU
         if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
         uses: docker/setup-qemu-action@v3
 
       - name: Build and test
-        if: matrix.os.matrix != 'windows'
-        env:
-          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
-          CIBW_BUILD: ${{ matrix.python.cibw-build }}
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
-          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
+        if: matrix.os.matrix == 'macos' || ( matrix.os.matrix == 'linux' && matrix.arch.matrix == 'intel' )
         run: |
+          pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
           cibuildwheel source --output-dir dist
+
+      - name: Build and test (QEMU)
+        if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
+        run: |
+          docker run --rm --platform linux/arm64 \
+          -v ${{ github.workspace }}:/ws \
+          --workdir=/ws \
+          quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
+          bash -exc ' \
+          pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
+          && cibuildwheel source --output-dir dist \
+          '
 
       - name: Build (Windows)
         if: matrix.os.matrix == 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build and test
         if: matrix.os.matrix != 'windows'
         env:
-          CIBW_ARCHS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
+          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
           CIBW_BUILD: ${{ matrix.python.cibw-build }}
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -154,6 +154,7 @@ jobs:
       - name: Install tools
         if: matrix.os.matrix != 'windows'
         run: |
+          python -m pip install --upgrade pip
           pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
 
       - name: Set up QEMU

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -42,6 +42,10 @@ jobs:
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
+            cibw-arch:
+              # TODO: do we need universal2?
+              arm: arm64
+              intel: x86_64
           - name: Linux
             file-name: linux
             matrix: linux
@@ -49,12 +53,17 @@ jobs:
             runs-on:
               arm: [ubuntu-latest]
               intel: [ubuntu-latest]
+            cibw-arch:
+              arm: aarch64
+              intel: x86_64
           - name: Windows
             file-name: windows
             matrix: windows
             emoji: 🪟
             runs-on:
               intel: [windows-latest]
+            cibw-arch:
+              intel: x86_64
         python:
           - major-dot-minor: '3.7'
             cibw-build: 'cp37-*'
@@ -129,7 +138,7 @@ jobs:
 
     env:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
-      CIBW_ARCHS: ${{ matrix.arch.cibw }}
+      CIBW_ARCHS: ${{ matrix.os.cibw[matrix.arch.matrix] }}
       CIBW_BUILD: ${{ matrix.python.cibw-build }}
       CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
       CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -115,6 +115,18 @@ jobs:
               matrix: arm
             python:
               matrix: '3.7'
+          - os:
+              matrix: macos
+            arch:
+              matrix: arm
+            python:
+              matrix: '3.8'
+          - os:
+              matrix: macos
+            arch:
+              matrix: arm
+            python:
+              matrix: '3.9'
 
     env:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Copy out miniupnpc
         run: |
-          cp --recursive --verbose cloned/miniupnpc source
+          cp --dereference --recursive --verbose cloned/miniupnpc source
 
       - name: Install tools
         if: matrix.os.matrix != 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -39,9 +39,6 @@ jobs:
             runs-on:
               arm: [macos-14]
               intel: [macos-latest]
-            cibw-archs-macos:
-              arm: arm64
-              intel: x86_64
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
@@ -99,9 +96,11 @@ jobs:
           - name: ARM
             file-name: arm
             matrix: arm
+            cibw: arm64
           - name: Intel
             file-name: intel
             matrix: intel
+            cibw: x86_64
         exclude:
 #          - os:  # excluding windows entirely as that is presently handled in AppVeyor
 #              matrix: windows
@@ -130,7 +129,7 @@ jobs:
 
     env:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
-      CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
+      CIBW_ARCHS: ${{ matrix.arch.cibw }}
       CIBW_BUILD: ${{ matrix.python.cibw-build }}
       CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
       CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
@@ -163,22 +162,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build and test
-        if: matrix.os.matrix == 'macos' || ( matrix.os.matrix == 'linux' && matrix.arch.matrix == 'intel' )
+        if: matrix.os.matrix != 'windows'
+#        if: matrix.os.matrix == 'macos' || ( matrix.os.matrix == 'linux' && matrix.arch.matrix == 'intel' )
         run: |
           pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
           cibuildwheel source --output-dir dist
 
-      - name: Build and test (QEMU)
-        if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
-        run: |
-          docker run --rm --platform linux/arm64 \
-          -v ${{ github.workspace }}:/ws \
-          --workdir=/ws \
-          quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
-          bash -exc ' \
-          python${{ matrix.python.major-dot-minor }} -m pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
-          && python${{ matrix.python.major-dot-minor }} -m cibuildwheel source --output-dir dist \
-          '
+#      - name: Build and test (QEMU)
+#        if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
+#        run: |
+#          docker run --rm --platform linux/arm64 \
+#          -v ${{ github.workspace }}:/ws \
+#          --workdir=/ws \
+#          quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
+#          bash -exc ' \
+#          python${{ matrix.python.major-dot-minor }} -m pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
+#          && python${{ matrix.python.major-dot-minor }} -m cibuildwheel source --output-dir dist \
+#          '
 
       - name: Build (Windows)
         if: matrix.os.matrix == 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -111,10 +111,10 @@ jobs:
         with:
           python-version: ${{ matrix.python.major-dot-minor }}
 
-      - uses: Chia-Network/actions/create-venv@main
+      - uses: ./.github/actions/create-venv
         id: create-venv
 
-      - uses: Chia-Network/actions/activate-venv@main
+      - uses: ./.github/actions/activate-venv
         with:
           directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
 
@@ -159,10 +159,10 @@ jobs:
           mkdir ../dist
           cp dist/*.whl ../dist
 
-      - uses: Chia-Network/actions/create-venv@main
+      - uses: ./.github/actions/create-venv
         id: create-test-venv
 
-      - uses: Chia-Network/actions/activate-venv@main
+      - uses: ./.github/actions/activate-venv
         with:
           directories: ${{ steps.create-test-venv.outputs.activate-venv-directories }}
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -1,0 +1,172 @@
+name: "build miniupnpc wheels"
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || format('{0}-{1}-{2}', github.ref, github.event_name, github.ref == 'refs/heads/main' && github.sha || '') }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.os.emoji }} 📦 Build ${{ matrix.arch.name }} ${{ matrix.python.major-dot-minor }}
+    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: macOS
+            matrix: macos
+            emoji: 🍎
+            runs-on:
+              arm: [macOS, ARM64]
+              intel: [macos-latest]
+            cibw-archs-macos:
+              arm: arm64
+              intel: x86_64
+            macosx-deployment-target:
+              arm: 11.0
+              intel: 10.14
+          - name: Linux
+            matrix: linux
+            emoji: 🐧
+            runs-on:
+              arm: [Linux, ARM64]
+              intel: [ubuntu-latest]
+          - name: Windows
+            matrix: windows
+            emoji: 🪟
+            runs-on:
+              intel: [windows-latest]
+        python:
+          - major-dot-minor: '3.7'
+            cibw-build: 'cp37-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2010
+            matrix: '3.7'
+          - major-dot-minor: '3.8'
+            cibw-build: 'cp38-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2010
+            matrix: '3.8'
+          - major-dot-minor: '3.9'
+            cibw-build: 'cp39-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2010
+            matrix: '3.9'
+          - major-dot-minor: '3.10'
+            cibw-build: 'cp310-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2010
+            matrix: '3.10'
+          - major-dot-minor: '3.11'
+            cibw-build: 'cp311-*'
+            manylinux:
+              arch: manylinux2014
+              intel: manylinux2014
+            matrix: '3.11'
+        arch:
+          - name: ARM
+            matrix: arm
+          - name: Intel
+            matrix: intel
+        exclude:
+          - os:
+              matrix: windows
+            arch:
+              matrix: arm
+          - os:
+              matrix: macos
+            arch:
+              matrix: arm
+            python:
+              matrix: '3.7'
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python.major-dot-minor }}
+
+      - uses: Chia-Network/actions/create-venv@main
+        id: create-venv
+
+      - uses: Chia-Network/actions/activate-venv@main
+        with:
+          directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: cloned
+
+      - name: Copy out miniupnpc
+        run: |
+          cp -R cloned/miniupnpc source
+
+      - name: Install tools
+        if: matrix.os.matrix != 'windows'
+        run: |
+          pip install cibuildwheel==2.11.2
+
+      - name: Build and test
+        if: matrix.os.matrix != 'windows'
+        env:
+          CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
+          CIBW_BUILD: ${{ matrix.python.cibw-build }}
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
+        run: |
+          cibuildwheel source --output-dir dist
+
+      - name: Build (Windows)
+        if: matrix.os.matrix == 'windows'
+        run: |
+          cd source
+          mingw32-make -f Makefile.mingw CC=gcc
+          python -m pip install wheel
+          mingw32-make -f Makefile.mingw pythonmodule PYTHON=python
+          7z a dist/*.whl miniupnpc.dll
+          mkdir ../dist
+          cp dist/*.whl ../dist
+
+      - uses: Chia-Network/actions/create-venv@main
+        id: create-test-venv
+
+      - uses: Chia-Network/actions/activate-venv@main
+        with:
+          directories: ${{ steps.create-test-venv.outputs.activate-venv-directories }}
+
+      - name: Install
+        run: |
+          pip install --no-index --only-binary :all: --find-links dist miniupnpc
+
+      - name: Import
+        run: |
+          python -c 'import miniupnpc; print(miniupnpc)'
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: wheel
+          path: ./dist
+          if-no-files-found: error

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Copy out miniupnpc
         run: |
-          cp --dereference --recursive --verbose cloned/miniupnpc source
+          cp -RLv cloned/miniupnpc source
 
       - name: Install tools
         if: matrix.os.matrix != 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Install tools
         if: matrix.os.matrix != 'windows'
         run: |
-          pip install cibuildwheel==2.16.5
+          pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"'
 
       - name: Set up QEMU
         if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -96,6 +96,8 @@ jobs:
           - name: Intel
             matrix: intel
         exclude:
+#          - os:  # excluding windows entirely as that is presently handled in AppVeyor
+#              matrix: windows
           - os:
               matrix: windows
             arch:

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -50,7 +50,7 @@ jobs:
             matrix: linux
             emoji: 🐧
             runs-on:
-              arm: [Linux, ARM64]
+              arm: [ubuntu-latest]
               intel: [ubuntu-latest]
           - name: Windows
             file-name: windows

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -96,7 +96,7 @@ jobs:
           - name: ARM
             file-name: arm
             matrix: arm
-            cibw: arm64
+            cibw: aarch64
           - name: Intel
             file-name: intel
             matrix: intel

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -124,16 +124,16 @@ jobs:
         with:
           python-version: ${{ matrix.python.major-dot-minor }}
 
+      - uses: actions/checkout@v4
+        with:
+          path: cloned
+
       - uses: ./.github/actions/create-venv
         id: create-venv
 
       - uses: ./.github/actions/activate-venv
         with:
           directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
-
-      - uses: actions/checkout@v4
-        with:
-          path: cloned
 
       - name: Copy out miniupnpc
         run: |

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -167,12 +167,12 @@ jobs:
           directories: ${{ steps.create-test-venv.outputs.activate-venv-directories }}
 
       - name: Install
-        if: "!( matrix.os.matrix == 'macos' && matrix.arch.matrix == 'arm')"
+        if: matrix.arch.matrix != 'arm'
         run: |
           pip install --no-index --only-binary :all: --find-links dist miniupnpc
 
       - name: Import
-        if: "!( matrix.os.matrix == 'macos' && matrix.arch.matrix == 'arm')"
+        if: matrix.arch.matrix != 'arm'
         run: |
           python -c 'import miniupnpc; print(miniupnpc)'
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -176,7 +176,7 @@ jobs:
           --workdir=/ws \
           quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
           bash -exc ' \
-          python${{ matrix.python.major-dot-minor }} pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
+          python${{ matrix.python.major-dot-minor }} -m pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
           && python${{ matrix.python.major-dot-minor }} -m cibuildwheel source --output-dir dist \
           '
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -1,3 +1,5 @@
+# copied from https://github.com/Chia-Network/build-wheels/blob/52e183920e3ec44017ed767c65e9b204536c0f13/.github/workflows/miniupnpc.yml
+
 name: "build miniupnpc wheels"
 
 on:
@@ -31,34 +33,31 @@ jobs:
       matrix:
         os:
           - name: macOS
+            file-name: macos
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-latest]
+              arm: [macOS, ARM64]
               intel: [macos-latest]
-            cibw-archs:
+            cibw-archs-macos:
               arm: arm64
               intel: x86_64
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
           - name: Linux
+            file-name: linux
             matrix: linux
             emoji: 🐧
             runs-on:
-              arm: [ubuntu-latest]
+              arm: [Linux, ARM64]
               intel: [ubuntu-latest]
-            cibw-archs:
-              arm: aarch64
-              intel: x86_64
           - name: Windows
+            file-name: windows
             matrix: windows
             emoji: 🪟
             runs-on:
               intel: [windows-latest]
-            cibw-archs:
-              arm: ARM64
-              intel: AMD64
         python:
           - major-dot-minor: '3.7'
             cibw-build: 'cp37-*'
@@ -69,37 +68,39 @@ jobs:
           - major-dot-minor: '3.8'
             cibw-build: 'cp38-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2010
             matrix: '3.8'
           - major-dot-minor: '3.9'
             cibw-build: 'cp39-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2010
             matrix: '3.9'
           - major-dot-minor: '3.10'
             cibw-build: 'cp310-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2010
             matrix: '3.10'
           - major-dot-minor: '3.11'
             cibw-build: 'cp311-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2014
             matrix: '3.11'
           - major-dot-minor: '3.12'
             cibw-build: 'cp312-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2014
             matrix: '3.12'
         arch:
           - name: ARM
+            file-name: arm
             matrix: arm
           - name: Intel
+            file-name: intel
             matrix: intel
         exclude:
 #          - os:  # excluding windows entirely as that is presently handled in AppVeyor
@@ -114,6 +115,10 @@ jobs:
               matrix: arm
             python:
               matrix: '3.7'
+
+    env:
+      FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
+
     steps:
       - uses: actions/setup-python@v4
         with:
@@ -126,7 +131,7 @@ jobs:
         with:
           directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: cloned
 
@@ -137,16 +142,16 @@ jobs:
       - name: Install tools
         if: matrix.os.matrix != 'windows'
         run: |
-          pip install cibuildwheel==2.11.2
+          pip install cibuildwheel==2.16.5
 
       - name: Set up QEMU
         if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Build and test
         if: matrix.os.matrix != 'windows'
         env:
-          CIBW_ARCHS: ${{ matrix.os.cibw-archs[matrix.arch.matrix] }}
+          CIBW_ARCHS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
           CIBW_BUILD: ${{ matrix.python.cibw-build }}
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
@@ -161,7 +166,7 @@ jobs:
         run: |
           cd source
           mingw32-make -f Makefile.mingw CC=gcc
-          python -m pip install wheel
+          python -m pip install setuptools wheel
           mingw32-make -f Makefile.mingw pythonmodule PYTHON=python
           7z a dist/*.whl miniupnpc.dll
           mkdir ../dist
@@ -184,9 +189,9 @@ jobs:
         run: |
           python -c 'import miniupnpc; print(miniupnpc)'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: wheel
+          name: wheel-${{ env.FILE_NAME }}
           path: ./dist
           if-no-files-found: error

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -37,8 +37,8 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macos-14]
-              intel: [macos-latest]
+              arm: [macOS, ARM64]
+              intel: [macOS, X86]
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
@@ -51,8 +51,9 @@ jobs:
             matrix: linux
             emoji: 🐧
             runs-on:
-              arm: [ubuntu-latest]
-              intel: [ubuntu-latest]
+              # using QEMU for arm
+              arm: [Linux, X86]
+              intel: [Linux, X86]
             cibw-archs:
               arm: aarch64
               intel: x86_64
@@ -61,7 +62,7 @@ jobs:
             matrix: windows
             emoji: 🪟
             runs-on:
-              intel: [windows-latest]
+              intel: [Windows, X86]
             cibw-archs:
               intel: x86_64
         python:

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -37,8 +37,8 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macOS, ARM64]
-              intel: [macOS, X86]
+              arm: [macos-14]
+              intel: [macos-latest]
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
@@ -51,9 +51,8 @@ jobs:
             matrix: linux
             emoji: 🐧
             runs-on:
-              # using QEMU for arm
-              arm: [Linux, X86]
-              intel: [Linux, X86]
+              arm: [ubuntu-latest]
+              intel: [ubuntu-latest]
             cibw-archs:
               arm: aarch64
               intel: x86_64
@@ -62,7 +61,7 @@ jobs:
             matrix: windows
             emoji: 🪟
             runs-on:
-              intel: [Windows, X86]
+              intel: [windows-latest]
             cibw-archs:
               intel: x86_64
         python:

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -62,7 +62,7 @@ jobs:
           - major-dot-minor: '3.7'
             cibw-build: 'cp37-*'
             manylinux:
-              arch: manylinux2014
+              arm: manylinux2014
               intel: manylinux2010
             matrix: '3.7'
           - major-dot-minor: '3.8'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -34,7 +34,7 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              arm: [macOS, ARM64]
+              arm: [macos-latest]
               intel: [macos-latest]
             cibw-archs-macos:
               arm: arm64
@@ -46,7 +46,6 @@ jobs:
             matrix: linux
             emoji: 🐧
             runs-on:
-#              arm: [Linux, ARM64]
               arm: [ubuntu-latest]
               intel: [ubuntu-latest]
           - name: Windows

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Copy out miniupnpc
         run: |
-          cp -R cloned/miniupnpc source
+          cp --recursive --verbose cloned/miniupnpc source
 
       - name: Install tools
         if: matrix.os.matrix != 'windows'

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -176,8 +176,8 @@ jobs:
           --workdir=/ws \
           quay.io/pypa/${{ matrix.python.manylinux[matrix.arch.matrix] }}_aarch64 \
           bash -exc ' \
-          pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
-          && cibuildwheel source --output-dir dist \
+          python${{ matrix.python.major-dot-minor }} pip install 'cibuildwheel==2.13.1; python_version < "3.8"' 'cibuildwheel==2.16.5; python_version >= "3.8"' \
+          && python${{ matrix.python.major-dot-minor }} -m cibuildwheel source --output-dir dist \
           '
 
       - name: Build (Windows)

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -42,7 +42,7 @@ jobs:
             macosx-deployment-target:
               arm: 11.0
               intel: 10.14
-            cibw-arch:
+            cibw-archs:
               # TODO: do we need universal2?
               arm: arm64
               intel: x86_64
@@ -53,7 +53,7 @@ jobs:
             runs-on:
               arm: [ubuntu-latest]
               intel: [ubuntu-latest]
-            cibw-arch:
+            cibw-archs:
               arm: aarch64
               intel: x86_64
           - name: Windows
@@ -62,7 +62,7 @@ jobs:
             emoji: 🪟
             runs-on:
               intel: [windows-latest]
-            cibw-arch:
+            cibw-archs:
               intel: x86_64
         python:
           - major-dot-minor: '3.7'
@@ -138,7 +138,7 @@ jobs:
 
     env:
       FILE_NAME: ${{ matrix.os.file-name }}-${{ matrix.arch.file-name }}-${{ matrix.python.major-dot-minor }}
-      CIBW_ARCHS: ${{ matrix.os.cibw[matrix.arch.matrix] }}
+      CIBW_ARCHS: ${{ matrix.os.cibw-archs[matrix.arch.matrix] }}
       CIBW_BUILD: ${{ matrix.python.cibw-build }}
       CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macosx-deployment-target[matrix.arch.matrix] }}
       CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -126,7 +126,7 @@ jobs:
           pip install cibuildwheel==2.11.2
 
       - name: Set up QEMU
-        if: matrix.arch.matrix == 'arm'
+        if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
         uses: docker/setup-qemu-action@v2
 
       - name: Build and test

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -128,10 +128,10 @@ jobs:
         with:
           path: cloned
 
-      - uses: ./.github/actions/create-venv
+      - uses: ./cloned/.github/actions/create-venv
         id: create-venv
 
-      - uses: ./.github/actions/activate-venv
+      - uses: ./cloned/.github/actions/activate-venv
         with:
           directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -1,3 +1,17 @@
+#    Copyright 2024 Chia Network Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 # copied from https://github.com/Chia-Network/build-wheels/blob/52e183920e3ec44017ed767c65e9b204536c0f13/.github/workflows/miniupnpc.yml
 
 name: "build miniupnpc wheels"

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -172,10 +172,10 @@ jobs:
           mkdir ../dist
           cp dist/*.whl ../dist
 
-      - uses: ./.github/actions/create-venv
+      - uses: ./cloned/.github/actions/create-venv
         id: create-test-venv
 
-      - uses: ./.github/actions/activate-venv
+      - uses: ./cloned/.github/actions/activate-venv
         with:
           directories: ${{ steps.create-test-venv.outputs.activate-venv-directories }}
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -161,10 +161,12 @@ jobs:
           directories: ${{ steps.create-test-venv.outputs.activate-venv-directories }}
 
       - name: Install
+        if: "!( matrix.os.matrix == 'macos' && matrix.arch.matrix == 'arm')"
         run: |
           pip install --no-index --only-binary :all: --find-links dist miniupnpc
 
       - name: Import
+        if: "!( matrix.os.matrix == 'macos' && matrix.arch.matrix == 'arm')"
         run: |
           python -c 'import miniupnpc; print(miniupnpc)'
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -46,7 +46,8 @@ jobs:
             matrix: linux
             emoji: 🐧
             runs-on:
-              arm: [Linux, ARM64]
+#              arm: [Linux, ARM64]
+              arm: [ubuntu-latest]
               intel: [ubuntu-latest]
           - name: Windows
             matrix: windows
@@ -124,6 +125,10 @@ jobs:
         if: matrix.os.matrix != 'windows'
         run: |
           pip install cibuildwheel==2.11.2
+
+      - name: Set up QEMU
+        if: matrix.arch.matrix == 'arm'
+        uses: docker/setup-qemu-action@v2
 
       - name: Build and test
         if: matrix.os.matrix != 'windows'


### PR DESCRIPTION
This adds wheel building CI in GitHub Actions for all operating systems and platforms except for Windows ARM. 
 This was requested in https://github.com/miniupnp/miniupnp/issues/616.  You can see builds in my fork at https://github.com/altendky/miniupnp/pull/1 as long as they aren't being run here.

Draft for:
- [x] Probably need to deal with the ARM builds differently
- [x] Probably want to not use `Chia-Network/actions`
- [x] Consider generating old-style manylinux wheels without the `manylinux_2_12` etc glibc version for pre-pip 20.3 compatibility
  - I would suggest not worrying about this at the moment.  It's not clear that we can properly create the old style presently and projects like `coverage` are using new-style only.  If really needed, maybe we can just do a file copy to the legacy naming style to get them.
- [ ] exclude windows builds
- [ ] look into m1 runners https://github.com/orgs/community/discussions/102846
- [ ] can we run linux arm on the m1 runners without needing qemu?
- [ ] maybe just unpin the cibuildwheel version?