### PR TITLE
nftnlrdr_misc.c: table_cb should cast handle as uint64_t

### DIFF
--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -571,7 +571,7 @@ table_cb(const struct nlmsghdr *nlh, void *data)
 					}
 				}
 
-				r->handle = *(uint32_t *) nftnl_rule_get_data(rule,
+				r->handle = *(uint64_t *) nftnl_rule_get_data(rule,
 															  NFTNL_RULE_HANDLE,
 															  &len);
 				r->type = CB_DATA(type);


### PR DESCRIPTION
Fixes #582 

The `table_cb` is run to process netfilter data

Fields are copied with appropriate parsing, casts, etc.

The `handle` field is cast as `uint32_t` but is defined and represented as `uint64_t`

https://github.com/miniupnp/miniupnp/blob/014c9df8ee7a36e5bf85aa619062a2d4b95ec8f6/miniupnpd/netfilter_nft/nftnlrdr_misc.c#L574-L576

https://github.com/miniupnp/miniupnp/blob/014c9df8ee7a36e5bf85aa619062a2d4b95ec8f6/miniupnpd/netfilter_nft/nftnlrdr_misc.h#L56

As a result, `handle` can be incorrectly truncated and is invalid for follow-up calls to netfilter (e.g. in `rule_del_handle`)

I determined this was an issue with -DDEBUG and the liberal addition of log_debug

Adding this here https://github.com/miniupnp/miniupnp/blob/014c9df8ee7a36e5bf85aa619062a2d4b95ec8f6/miniupnpd/netfilter_nft/nftnlrdr_misc.c#L1163

```
log_debug("XXX rule_del_handle - %s %s %d %hu => %hu (%llu)\n", rule->table, rule->chain, (int)rule->type, rule->eport, rule->iport, rule->handle);
```

gave me:

```
miniupnpd[6443]: rule_del_handle[1163]: XXX rule_del_handle - fw4 upnp_prerouting 1 63110 => 22000 (0)
```

where the (invalid) rule handle is the `0` in parens at the end 