### PR TITLE
Warning when setting index string with sprintf

### DIFF
--- a/miniupnpc/src/upnpc.c
+++ b/miniupnpc/src/upnpc.c
@@ -150,7 +150,7 @@ static void ListRedirections(struct UPNPUrls * urls,
 	printf("PortMappingNumberOfEntries : %u\n", num);*/
 	printf(" i protocol exPort->inAddr:inPort description remoteHost leaseTime\n");
 	do {
-		snprintf(index, 6, "%d", i);
+		snprintf(index, 6, "%d", i % 100000);
 		rHost[0] = '\0'; enabled[0] = '\0';
 		duration[0] = '\0'; desc[0] = '\0';
 		extPort[0] = '\0'; intPort[0] = '\0'; intClient[0] = '\0';


### PR DESCRIPTION

‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 6 [-Werror=format-truncation=]