### PR TITLE
github workflows: bump actions versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
        make -C minissdpd all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/i586-mingw32msvc.yml
+++ b/.github/workflows/i586-mingw32msvc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: download packages
         run: wget -c https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-binutils_2.20-0.2ubuntu1_amd64.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-runtime_3.15.2-0ubuntu1_all.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32_4.2.1.dfsg-2ubuntu1_amd64.deb

--- a/.github/workflows/i686-w64-mingw32.yml
+++ b/.github/workflows/i686-w64-mingw32.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install packages
         run: sudo apt-get install gcc-mingw-w64-i686 mingw-w64-tools
@@ -29,7 +29,7 @@ jobs:
         run: make -C miniupnpc -f Makefile.mingw DLLWRAP=i686-w64-mingw32-dllwrap CC=i686-w64-mingw32-gcc WINDRES=i686-w64-mingw32-windres AR=i686-w64-mingw32-ar all dist
 
       - name: upload binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: miniupnpc-win32-binaries-${{github.sha}}
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: build miniupnpc with make
         run: make -C miniupnpc all check
@@ -43,7 +43,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install packages
         run: sudo apt-get install libnfnetlink-dev

--- a/.github/workflows/miniupnpd.yml
+++ b/.github/workflows/miniupnpd.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install packages
         run: sudo apt-get install libiptc-dev libxtables-dev libnfnetlink-dev libnftnl-dev libmnl-dev libssl-dev

--- a/.github/workflows/x86_64-w64-mingw32.yml
+++ b/.github/workflows/x86_64-w64-mingw32.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install packages
         run: sudo apt-get install gcc-mingw-w64-x86-64 mingw-w64-tools
@@ -19,7 +19,7 @@ jobs:
         run: make -C miniupnpc -f Makefile.mingw DLLWRAP=x86_64-w64-mingw32-dllwrap CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres AR=x86_64-w64-mingw32-ar all dist
 
       - name: upload binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: miniupnpc-win64-binaries-${{github.sha}}
           path: |


### PR DESCRIPTION
Fix errors and warnings found in GitHub Actions like these ones : 
- https://github.com/miniupnp/miniupnp/actions/runs/4019853462
> This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported. For better performance, improved security, and new features, upgrade to v2. [...]

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, github/codeql-action/init@v1, github/codeql-action/analyze@v1. [...]
- https://github.com/miniupnp/miniupnp/actions/runs/4019853465
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. [...]