### PR TITLE
podspec: point to miniupnp/miniupnp repo

### DIFF
--- a/miniupnp.podspec
+++ b/miniupnp.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
 
   spec.version = "2.0.0.2"
   spec.source = {
-      git: 'https://github.com/cpp-ethereum-ios/miniupnp.git',
+      git: 'https://github.com/miniupnp/miniupnp.git',
       tag: "v#{spec.version}"
   }
 


### PR DESCRIPTION
It's not clear to me why this is pointing to a fork of this repository (which has been marked as archived for nearly 3 years).

I guess this can be updated to point to this repo, or the podspec removed entirely if there is no interest in maintaining it?