### PR TITLE
minissdpc.c: fix memory allocation error

### DIFF
--- a/miniupnpc/src/minissdpc.c
+++ b/miniupnpc/src/minissdpc.c
@@ -338,7 +338,7 @@ receiveDevicesFromMiniSSDPD(int s, int * error)
 #ifdef DEBUG
 		printf("   usnsize=%u\n", usnsize);
 #endif /* DEBUG */
-		tmp = (struct UPNPDev *)malloc(sizeof(struct UPNPDev)+urlsize+stsize+usnsize);
+		tmp = (struct UPNPDev *)malloc(sizeof(struct UPNPDev)+urlsize+stsize+usnsize+3);
 		if(tmp == NULL) {
 			if (error)
 				*error = MINISSDPC_MEMORY_ERROR;


### PR DESCRIPTION
No room allocated for end of strings ("\0")