### PR TITLE
FreeBSD: use libpfctl

### DIFF
--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -627,6 +627,12 @@ if [ "$MAKEFILE" = "Makefile.bsd" ] || [ "$OS_NAME" = "Darwin" ] || [ "$OS_NAME"
 	echo "FWNAME = $FW" > bsdmake.inc
 	echo "SRCDIR = ${BASEDIR}" >> bsdmake.inc
 	echo "CPPFLAGS += -I." >> bsdmake.inc
+	if [ "$OS_NAME" = "FreeBSD" ] && [ "$FW" = "pf" ] ; then
+		echo "#define USE_LIBPFCTL 1" >> ${CONFIGFILE}
+		echo "CFLAGS += -I/usr/local/include/" >> bsdmake.inc
+		echo "LDFLAGS += -L/usr/local/lib" >> bsdmake.inc
+		echo "LDFLAGS += -lpfctl" >> bsdmake.inc
+	fi
 fi
 if [ "$MAKEFILE" ] ; then
 	cp "${BASEDIR}/${MAKEFILE}" Makefile && echo "${BASEDIR}/${MAKEFILE} -> Makefile"


### PR DESCRIPTION
FreeBSD 15 has removed several ioctl calls (such as DIOCGETSTATUS and DIOCGETRULE) and replaced them. The easiest way to cope with that is to use the provided libpfctl library.

NOTE: This version of the patch will break use on OpenBSD or NetBSD and is intended to serve as a basis for discussing the best approach to cope with these differences.

Sponsored by:	Rubicon Communications, LLC ("Netgate")