### PR TITLE
Fix for OpenBSD 7.4

### DIFF
--- a/miniupnpd/pf/pfpinhole.c
+++ b/miniupnpd/pf/pfpinhole.c
@@ -1,8 +1,8 @@
-/* $Id: pfpinhole.c,v 1.29 2020/05/10 22:22:50 nanard Exp $ */
+/* $Id: pfpinhole.c,v 1.30 2023/12/07 18:56:48 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * MiniUPnP project
  * http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
- * (c) 2012-2020 Thomas Bernard
+ * (c) 2012-2023 Thomas Bernard
  * This software is subject to the conditions detailed
  * in the LICENCE file provided within the distribution */
 
@@ -54,6 +54,17 @@ static int next_uid = 1;
 
 #define PINEHOLE_LABEL_FORMAT "pinhole-%d ts-%u: %s"
 #define PINEHOLE_LABEL_FORMAT_SKIPDESC "pinhole-%d ts-%u: %*s"
+
+#if defined(PF_NEWSTYLE) && defined(DIOCXEND)
+#define PF_RELEASETICKETS
+#define release_ticket(device, ticket_num) {\
+	if (ioctl((device), DIOCXEND, &(ticket_num)) < 0) {\
+		syslog(LOG_ERR, "ioctl(dev, DIOCXEND, ...): %m");\
+	}\
+}
+#else
+#define release_ticket(device, ticket_num)	(void)(ticket_num)
+#endif
 
 int add_pinhole(const char * ifname,
                 const char * rem_host, unsigned short rem_port,
@@ -167,7 +178,7 @@ int find_pinhole(const char * ifname,
                  char *desc, int desc_len, unsigned int * timestamp)
 {
 	int uid;
-	unsigned int ts;
+	unsigned int ts, tnum;
 	int i, n;
 	struct pfioc_rule pr;
 	struct in6_addr saddr;
@@ -194,10 +205,14 @@ int find_pinhole(const char * ifname,
 		return -1;
 	}
 	n = pr.nr;
+#ifdef PF_RELEASETICKETS
+	tnum = pr.ticket;
+#endif /* PF_RELEASETICKETS */
 	for(i=0; i<n; i++) {
 		pr.nr = i;
 		if(ioctl(dev, DIOCGETRULE, &pr) < 0) {
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
+			release_ticket(dev, tnum);
 			return -1;
 		}
 		if((proto == pr.rule.proto) && (rem_port == ntohs(pr.rule.src.port[0]))
@@ -216,15 +231,18 @@ int find_pinhole(const char * ifname,
 					strlcpy(desc, p, desc_len);
 				}
 			}
+			release_ticket(dev, tnum);
 			return uid;
 		}
 	}
+	release_ticket(dev, tnum);
 	return -2;
 }
 
 int delete_pinhole(unsigned short uid)
 {
 	int i, n;
+	unsigned int tnum;
 	struct pfioc_rule pr;
 	char label_start[PF_RULE_LABEL_SIZE];
 	char tmp_label[PF_RULE_LABEL_SIZE];
@@ -245,6 +263,9 @@ int delete_pinhole(unsigned short uid)
 		return -1;
 	}
 	n = pr.nr;
+#ifdef PF_RELEASETICKETS
+	tnum = pr.ticket;
+#endif
 	for(i=0; i<n; i++) {
 		pr.nr = i;
 		if(ioctl(dev, DIOCGETRULE, &pr) < 0) {
@@ -257,17 +278,21 @@ int delete_pinhole(unsigned short uid)
 			pr.action = PF_CHANGE_GET_TICKET;
 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_GET_TICKET: %m");
+				release_ticket(dev, tnum);
 				return -1;
 			}
 			pr.action = PF_CHANGE_REMOVE;
 			pr.nr = i;
 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+				release_ticket(dev, tnum);
 				return -1;
 			}
+			release_ticket(dev, tnum);
 			return 0;
 		}
 	}
+	release_ticket(dev, tnum);
 	/* not found */
 	return -2;
 }
@@ -281,6 +306,7 @@ get_pinhole_info(unsigned short uid,
                  u_int64_t * packets, u_int64_t * bytes)
 {
 	int i, n;
+	unsigned int tnum;
 	struct pfioc_rule pr;
 	char label_start[PF_RULE_LABEL_SIZE];
 	char tmp_label[PF_RULE_LABEL_SIZE];
@@ -302,10 +328,14 @@ get_pinhole_info(unsigned short uid,
 		return -1;
 	}
 	n = pr.nr;
+#ifdef PF_RELEASETICKETS
+	tnum = pr.ticket;
+#endif
 	for(i=0; i<n; i++) {
 		pr.nr = i;
 		if(ioctl(dev, DIOCGETRULE, &pr) < 0) {
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
+			release_ticket(dev, tnum);
 			return -1;
 		}
 		strlcpy(tmp_label, pr.rule.label, sizeof(tmp_label));
@@ -313,11 +343,13 @@ get_pinhole_info(unsigned short uid,
 		strsep(&p, " ");
 		if(0 == strcmp(tmp_label, label_start)) {
 			if(rem_host && (inet_ntop(AF_INET6, &pr.rule.src.addr.v.a.addr.v6, rem_host, rem_hostlen) == NULL)) {
+				release_ticket(dev, tnum);
 				return -1;
 			}
 			if(rem_port)
 				*rem_port = ntohs(pr.rule.src.port[0]);
 			if(int_client && (inet_ntop(AF_INET6, &pr.rule.dst.addr.v.a.addr.v6, int_client, int_clientlen) == NULL)) {
+				release_ticket(dev, tnum);
 				return -1;
 			}
 			if(int_port)
@@ -345,9 +377,11 @@ get_pinhole_info(unsigned short uid,
 			if(bytes)
 				*bytes = pr.rule.bytes;
 #endif
+			release_ticket(dev, tnum);
 			return 0;
 		}
 	}
+	release_ticket(dev, tnum);
 	/* not found */
 	return -2;
 }
@@ -370,7 +404,7 @@ int clean_pinhole_list(unsigned int * next_timestamp)
 	int i;
 	struct pfioc_rule pr;
 	time_t current_time;
-	unsigned int ts;
+	unsigned int ts, tnum;
 	int uid;
 	unsigned int min_ts = UINT_MAX;
 	int min_uid = INT_MAX, max_uid = -1;
@@ -390,10 +424,14 @@ int clean_pinhole_list(unsigned int * next_timestamp)
 		syslog(LOG_ERR, "ioctl(dev, DIOCGETRULES, ...): %m");
 		return -1;
 	}
+#ifdef PF_RELEASETICKETS
+	tnum = pr.ticket;
+#endif
 	for(i = pr.nr - 1; i >= 0; i--) {
 		pr.nr = i;
 		if(ioctl(dev, DIOCGETRULE, &pr) < 0) {
 			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
+			release_ticket(dev, tnum);
 			return -1;
 		}
 		if(sscanf(pr.rule.label, PINEHOLE_LABEL_FORMAT_SKIPDESC, &uid, &ts) != 2) {
@@ -405,22 +443,28 @@ int clean_pinhole_list(unsigned int * next_timestamp)
 			pr.action = PF_CHANGE_GET_TICKET;
 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_GET_TICKET: %m");
+				release_ticket(dev, tnum);
 				return -1;
 			}
 			pr.action = PF_CHANGE_REMOVE;
 			pr.nr = i;
 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_REMOVE: %m");
+				release_ticket(dev, tnum);
 				return -1;
 			}
 			n++;
 #ifndef PF_NEWSTYLE
 			pr.rule.action = PF_PASS;
 #endif
+			release_ticket(dev, tnum);
 			if(ioctl(dev, DIOCGETRULES, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCGETRULES, ...): %m");
 				return -1;
 			}
+#ifdef PF_RELEASETICKETS
+			tnum = pr.ticket;
+#endif
 		} else {
 			if(uid > max_uid)
 				max_uid = uid;
@@ -440,6 +484,7 @@ int clean_pinhole_list(unsigned int * next_timestamp)
 			next_uid = 1;
 		}
 	}
+	release_ticket(dev, tnum);
 	return n;	/* number of rules removed */
 }
 


### PR DESCRIPTION
Fixes a change made in pf on OpenBSD 7.4 where one needs to now call `DIOCXEND` for every call to `DIOCGETRULES`. There is now a finite number of tickets, and exceeding this just results in a 'Device busy' error when calling `DIOCGETRULES`. Without this fix, miniupnpd gets to a state where it cannot add/remove any rules.

Here's the relevant part from the 7.4 changelog:
```
Speed up the ioctl(2) request DIOCGETRULE such that pfctl(8)
can retrieve all pf(4) rules from the kernel in linear rather than
in quadratic time. To protect the kernel from memory exhaustion,
userland processes now have to release tickets obtained with
DIOCGETRULES by issuing the new ioctl(2) request DIOCXEND.
In particular, snmpd(8) and systat(1) now do that.
```