### PR TITLE
miniupnpd: Consider secure mode also for UPnP IGD pinholes

### DIFF
--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -1634,7 +1634,7 @@ PinholeVerification(struct upnphttp * h, char * int_ip, unsigned short int_port)
 		strncpy(clientaddr_str, "*ERROR*", sizeof(clientaddr_str));
 	}
 
-	if(memcmp(&h->clientaddr_v6, &result_ip, sizeof(struct in6_addr)) != 0)
+	if(GETFLAG(SECUREMODEMASK) && (memcmp(&h->clientaddr_v6, &result_ip, sizeof(struct in6_addr)) != 0))
 	{
 		syslog(LOG_INFO, "%s: Client %s tried to access pinhole for internal %s and is not authorized",
 		       "PinholeVerification", clientaddr_str, int_ip);


### PR DESCRIPTION
Previously, secure mode was always enabled for pinholes.