### PR TITLE
miniupnpc: Fix UPnP UDA 1.1 content-type charset compliance

### DIFF
--- a/miniupnpc-async/miniupnpc-async.c
+++ b/miniupnpc-async/miniupnpc-async.c
@@ -400,7 +400,7 @@ static int upnpc_send_request(upnpc_device_t * p)
 	static const char reqfmt[] = "GET %s HTTP/1.1\r\n"
 		"Host: %s:%hu\r\n"
 		"Connection: Close\r\n"
-		"User-Agent: MiniUPnPc-async\r\n"
+		"User-Agent: OS/version UPnP/1.1 MiniUPnPc-async/2.2\r\n"
 		"\r\n";
 
 	/* retrieve "our" IP address used to connect to the UPnP device */
@@ -689,9 +689,9 @@ static int upnpc_build_soap_request(upnpc_device_t * p, const char * url,
 	const char fmt_http[] =
 		"POST %s HTTP/1.1\r\n"
 		"Host: %s%s\r\n"
-		"User-Agent: MiniUPnPc-async\r\n"
+		"User-Agent: OS/version UPnP/1.1 MiniUPnPc-async/2.2\r\n"
 		"Content-Length: %d\r\n"
-		"Content-Type: text/xml\r\n"
+		"Content-Type: text/xml charset=\"utf-8\"\r\n"
 		"SOAPAction: \"%s#%s\"\r\n"
 		"Connection: Close\r\n"
 		"Cache-Control: no-cache\r\n"	/* ??? */

--- a/miniupnpc-libevent/miniupnpc-libevent.c
+++ b/miniupnpc-libevent/miniupnpc-libevent.c
@@ -528,7 +528,7 @@ static int upnpc_get_desc(upnpc_device_t * d, const char * url)
 	headers = evhttp_request_get_output_headers(req);
 	evhttp_add_header(headers, "Host", hostname_port);
 	evhttp_add_header(headers, "Connection", "close");
-	/*evhttp_add_header(headers, "User-Agent", "***");*/
+	/*evhttp_add_header(headers, "User-Agent", "OS/version UPnP/1.1 MiniUPnPc-libevent/2.2");*/
 	return evhttp_make_request(d->desc_conn, req, EVHTTP_REQ_GET, path);
 }
 
@@ -644,8 +644,8 @@ static int upnpc_send_soap_request(upnpc_device_t * p, const char * url,
 	buffer = evhttp_request_get_output_buffer(req);
 	evhttp_add_header(headers, "Host", hostname_port);
 	evhttp_add_header(headers, "SOAPAction", action);
-	evhttp_add_header(headers, "Content-Type", "text/xml");
-	/*evhttp_add_header(headers, "User-Agent", "***");*/
+	evhttp_add_header(headers, "Content-Type", "text/xml; charset=\"utf-8\"");
+	/*evhttp_add_header(headers, "User-Agent", "OS/version UPnP/1.1 MiniUPnPc-libevent/2.2");*/
 	/*evhttp_add_header(headers, "Cache-Control", "no-cache");*/
 	/*evhttp_add_header(headers, "Pragma", "no-cache");*/
 	evbuffer_add(buffer, body, body_len);
@@ -958,7 +958,7 @@ int upnpc_event_subscribe(upnpc_device_t * p)
 	headers = evhttp_request_get_output_headers(req);
 	/*buffer = evhttp_request_get_output_buffer(req);*/
 	evhttp_add_header(headers, "Host", hostname_port);
-	/*evhttp_add_header(headers, "User-Agent", "***");*/
+	/*evhttp_add_header(headers, "User-Agent", "OS/version UPnP/1.1 MiniUPnPc-libevent/2.2");*/
 	snprintf(callback_header, sizeof(callback_header), "<http://%s:%hu/evt_conn>", p->parent->local_address, p->parent->local_port);
 	evhttp_add_header(headers, "Callback", callback_header);
 	evhttp_add_header(headers, "NT", "upnp:event");


### PR DESCRIPTION
and user-agent also in asynchronous sample code. The commits https://github.com/miniupnp/miniupnp/commit/a6aa3711668247c660699cd285d5bfffaa739324 and https://github.com/miniupnp/miniupnp/commit/b557fdf4db713aee838669970bad02498a1c5d86 were incomplete.

Field value MUST be "text/xml; charset="utf-8"".
Field value MUST be "text/xml; charset="utf-8"" for description documents.
https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v1.1.pdf