### PR TITLE
miniupnpc: Set default lease time to 3600 to fix UPnP IGDv2 compliance

### DIFF
--- a/miniupnpc/src/upnpc.c
+++ b/miniupnpc/src/upnpc.c
@@ -767,7 +767,7 @@ int main(int argc, char ** argv)
 				if (SetRedirectAndTest(&urls, &data,
 						   commandargv[0], commandargv[1],
 						   commandargv[2], commandargv[3],
-						   (commandargc > 4) && is_int(commandargv[4]) ? commandargv[4] : "0",
+						   (commandargc > 4) && is_int(commandargv[4]) ? commandargv[4] : "3600",
 						   (commandargc > 4) && !is_int(commandargv[4]) ? commandargv[4] : (commandargc > 5) ? commandargv[5] : NULL,
 						   description, 0) < 0)
 					retcode = 2;
@@ -781,7 +781,7 @@ int main(int argc, char ** argv)
 				if (SetRedirectAndTest(&urls, &data,
 						   commandargv[0], commandargv[1],
 						   commandargv[2], commandargv[3],
-						   (commandargc > 4) && is_int(commandargv[4]) ? commandargv[4] : "0",
+						   (commandargc > 4) && is_int(commandargv[4]) ? commandargv[4] : "3600",
 						   (commandargc > 4) && !is_int(commandargv[4]) ? commandargv[4] : (commandargc > 5) ? commandargv[5] : NULL,
 						   description, 1) < 0)
 					retcode = 2;

--- a/miniupnpc/src/upnpcommands.c
+++ b/miniupnpc/src/upnpcommands.c
@@ -373,7 +373,7 @@ UPNP_AddPortMapping(const char * controlURL, const char * servicetype,
 	AddPortMappingArgs[6].elt = "NewPortMappingDescription";
 	AddPortMappingArgs[6].val = desc?desc:"libminiupnpc";
 	AddPortMappingArgs[7].elt = "NewLeaseDuration";
-	AddPortMappingArgs[7].val = leaseDuration?leaseDuration:"0";
+	AddPortMappingArgs[7].val = leaseDuration?leaseDuration:"3600";
 	buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                           "AddPortMapping", AddPortMappingArgs,
 	                           &bufsize);
@@ -437,7 +437,7 @@ UPNP_AddAnyPortMapping(const char * controlURL, const char * servicetype,
 	AddPortMappingArgs[6].elt = "NewPortMappingDescription";
 	AddPortMappingArgs[6].val = desc?desc:"libminiupnpc";
 	AddPortMappingArgs[7].elt = "NewLeaseDuration";
-	AddPortMappingArgs[7].val = leaseDuration?leaseDuration:"0";
+	AddPortMappingArgs[7].val = leaseDuration?leaseDuration:"3600";
 	buffer = simpleUPnPcommand(-1, controlURL, servicetype,
 	                           "AddAnyPortMapping", AddPortMappingArgs,
 	                           &bufsize);


### PR DESCRIPTION
It is RECOMMENDED that a lease time of 3600 seconds would be used as a default value.
http://upnp.org/specs/gw/UPnP-gw-WANIPConnection-v2-Service.pdf