### PR TITLE
upnpc: Show hint to use IPv6 (option -6) for pinhole commands

### DIFF
--- a/miniupnpc/src/upnpc.c
+++ b/miniupnpc/src/upnpc.c
@@ -691,6 +691,10 @@ int main(int argc, char ** argv)
 		return 1;
 	}
 
+	if(ipv6 == 0 && (command == 'A' || command == 'D' || command == 'U' || command == 'K' || command == 'C' || command == 'G')) {
+		printf("Use IPv6 (option -6) GUA address to ensure UPnP IGDv2 pinholes are allowed\n\n");
+	}
+
 	if( rootdescurl
 	  || (devlist = upnpDiscover(2000, multicastif, minissdpdpath,
 	                             localport, ipv6, ttl, &error)))


### PR DESCRIPTION
Control points that have not been authenticated and authorized as defined in IGDv2 SHOULD use their
IPv6 GUA when calling this action.
http://upnp.org/specs/gw/UPnP-gw-WANIPv6FirewallControl-v1-Service.pdf