### PR TITLE
miniupnpd: Fix default config path, set to /etc/miniupnpd/miniupnpd.conf

### DIFF
--- a/miniupnpd/INSTALL
+++ b/miniupnpd/INSTALL
@@ -126,7 +126,7 @@ https://miniupnp.tuxfamily.org/forum/viewtopic.php?p=4370
 https://github.com/miniupnp/miniupnp/pull/114
 
 =========================== Configuration =============================
-Edit the /etc/miniupnpd.conf file to set options. Almost all options are
+Edit the /etc/miniupnpd/miniupnpd.conf file to set options. Almost all options are
 also available through command line switches.
 
 A basic configuration would set :

--- a/miniupnpd/Makefile.bsd
+++ b/miniupnpd/Makefile.bsd
@@ -127,7 +127,7 @@ LIBS += -lssl -lcrypto
 # set PREFIX variable to install in the wanted place
 
 INSTALLBINDIR = $(PREFIX)/sbin
-INSTALLETCDIR = $(PREFIX)/etc
+INSTALLETCDIR = $(PREFIX)/etc/miniupnpd
 MANPREFIX ?= $(PREFIX)
 INSTALLMANDIR = $(MANPREFIX)/man
 

--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -874,6 +874,10 @@ echo "/* disable reading and parsing of config file (miniupnpd.conf) */" >> ${CO
 echo "/*#define DISABLE_CONFIG_FILE*/" >> ${CONFIGFILE}
 echo "" >> ${CONFIGFILE}
 
+echo "/* Set default config file path, if not set, /etc/miniupnpd/miniupnpd.conf will be used */" >> ${CONFIGFILE}
+echo "/*#define DEFAULT_CONFIG \"/etc/miniupnpd/miniupnpd.conf\"*/" >> ${CONFIGFILE}
+echo "" >> ${CONFIGFILE}
+
 echo "/* Uncomment the following line to configure all manufacturer infos through miniupnpd.conf */" >> ${CONFIGFILE}
 if [ -n "$VENDORCFG" ] ; then
 	echo "#define ENABLE_MANUFACTURER_INFO_CONFIGURATION" >> ${CONFIGFILE}

--- a/miniupnpd/miniupnpd.8
+++ b/miniupnpd/miniupnpd.8
@@ -18,7 +18,7 @@ clients on the LAN to ask for port redirections.
 .SH OPTIONS
 .TP
 .BI \-f " config_file"
-load the config from file. default is /etc/miniupnpd.conf.
+load the config from file. default is /etc/miniupnpd/miniupnpd.conf.
 .TP
 .BI \-i " ext_ifname"
 interface used to connect to the internet.

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -102,7 +102,7 @@ void init_iptpinhole(void);
 #endif
 
 #ifndef DEFAULT_CONFIG
-#define DEFAULT_CONFIG "/etc/miniupnpd.conf"
+#define DEFAULT_CONFIG "/etc/miniupnpd/miniupnpd.conf"
 #endif
 
 #ifdef USE_MINIUPNPDCTL


### PR DESCRIPTION
to match the path used by the makefiles and distributions. Create a DEFAULT_CONFIG define during configure.

The configuration file installed by the makefiles was not used on Linux before.