### PR TITLE
miniupnpd: Add daemon version to XML (child) device descriptions

### DIFF
--- a/miniupnpd/upnpdescstrings.h
+++ b/miniupnpd/upnpdescstrings.h
@@ -22,19 +22,19 @@
 #define WANDEV_MANUFACTURERURL		"https://miniupnp.tuxfamily.org/"
 #define WANDEV_MODELNAME			"WAN Device"
 #define WANDEV_MODELDESCRIPTION		"WAN Device"
-#define WANDEV_MODELNUMBER			MINIUPNPD_DATE
+#define WANDEV_MODELNUMBER			MINIUPNPD_VERSION "@" MINIUPNPD_DATE
 #define WANDEV_MODELURL				"https://miniupnp.tuxfamily.org/"
-#define WANDEV_UPC					"000000000000"
+#define WANDEV_UPC					""
 /* UPC is 12 digit (barcode) */
 
 #define WANCDEV_FRIENDLYNAME		"WANConnectionDevice"
 #define WANCDEV_MANUFACTURER		WANDEV_MANUFACTURER
 #define WANCDEV_MANUFACTURERURL		WANDEV_MANUFACTURERURL
-#define WANCDEV_MODELNAME			"MiniUPnPd"
-#define WANCDEV_MODELDESCRIPTION	"MiniUPnP daemon"
-#define WANCDEV_MODELNUMBER			MINIUPNPD_DATE
+#define WANCDEV_MODELNAME			"WAN Connection Device"
+#define WANCDEV_MODELDESCRIPTION	"WAN Connection Device"
+#define WANCDEV_MODELNUMBER			MINIUPNPD_VERSION "@" MINIUPNPD_DATE
 #define WANCDEV_MODELURL			"https://miniupnp.tuxfamily.org/"
-#define WANCDEV_UPC					"000000000000"
+#define WANCDEV_UPC					""
 /* UPC is 12 digit (barcode) */
 
 #endif

--- a/miniupnpd/upnpglobalvars.c
+++ b/miniupnpd/upnpglobalvars.c
@@ -65,9 +65,9 @@ const char * pidfilename = "/var/run/miniupnpd.pid";
 char uuidvalue_igd[] = "uuid:00000000-0000-0000-0000-000000000000";
 char uuidvalue_wan[] = "uuid:00000000-0000-0000-0000-000000000000";
 char uuidvalue_wcd[] = "uuid:00000000-0000-0000-0000-000000000000";
-char serialnumber[SERIALNUMBER_MAX_LEN] = "00000000";
+char serialnumber[SERIALNUMBER_MAX_LEN] = "";
 
-char modelnumber[MODELNUMBER_MAX_LEN] = "1";
+char modelnumber[MODELNUMBER_MAX_LEN] = "";
 
 /* presentation url :
  * http://nnn.nnn.nnn.nnn:ppppp/  => max 30 bytes including terminating 0 */


### PR DESCRIPTION
in addition to the build date and remove dummy strings for model/serial number and some harmonisations.