### PR TITLE
Allow the use of IPv4 address mask when built with IPv6 support but disabled at runtime

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1057,11 +1057,13 @@ parselanaddr(struct lan_addr_s * lan_addr, const char * str, int debug_flag)
 		}
 	} else {
 #ifdef ENABLE_IPV6
-		INIT_PRINT_ERR("Error: please specify LAN network interface by name instead of IPv4 address : %s\n", str);
-		return -1;
-#else
-		syslog(LOG_NOTICE, "it is advised to use network interface name instead of %s", str);
+		if(!GETFLAG(IPV6DISABLEDMASK))
+		{
+			INIT_PRINT_ERR("Error: please specify LAN network interface by name instead of IPv4 address : %s\n", str);
+			return -1;
+		}
 #endif
+		syslog(LOG_NOTICE, "it is advised to use network interface name instead of %s", str);
 	}
 	return 0;
 parselan_error:


### PR DESCRIPTION
So the default binaries on OpenWRT have IPv6 support built in but if you use the runtime config option
`ipv6_disable` to disable IPv6 you still can't set `listening_ip` to an address mask like `10.0.0.1/24`.

This tiny change corrects that issue and allows the IP address mask to be supplied.

I changed the flow slightly so that the syslog warning did not have to be duplicated.

I couldn't see a test for this code path but I did run a full build