### PR TITLE
add pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -238,6 +238,10 @@ jobs:
           pattern: wheel-*
           path: dist/
 
+      - name: List all artifacts
+        run: |
+          ls -la dist/
+
       - name: Publish distribution to PyPI
         # TODO: identify the desired condition
         if: false

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -243,8 +243,7 @@ jobs:
           ls -la dist/
 
       - name: Publish to PyPI
-        # TODO: identify the desired condition
-        if: false
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -238,7 +238,7 @@ jobs:
           pattern: wheel-*
           path: dist/
 
-      - name: List all artifacts
+      - name: List artifacts
         run: |
           ls -la dist/
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -226,7 +226,7 @@ jobs:
           if-no-files-found: error
 
   upload:
-    name: ${{ matrix.os.emoji }} 📦 Build ${{ matrix.arch.name }} ${{ matrix.python.major-dot-minor }}
+    name: 🚀 Upload
     runs-on: ubuntu-latest
     needs: build
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -244,4 +244,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          print-hash: true
           skip-existing: true
+          verbose: true

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -242,7 +242,7 @@ jobs:
         run: |
           ls -la dist/
 
-      - name: Publish distribution to PyPI
+      - name: Publish to PyPI
         # TODO: identify the desired condition
         if: false
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -231,7 +231,7 @@ jobs:
     needs: build
 
     steps:
-      - name: Download Results
+      - name: Download results
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -224,3 +224,24 @@ jobs:
           name: wheel-${{ env.FILE_NAME }}
           path: ./dist
           if-no-files-found: error
+
+  upload:
+    name: ${{ matrix.os.emoji }} 📦 Build ${{ matrix.arch.name }} ${{ matrix.python.major-dot-minor }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download Results
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: wheel-*
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        # TODO: identify the desired condition
+        if: false
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
PyPA has provided a specific action for uploading to PyPI.  https://github.com/pypa/gh-action-pypi-publish  It can be used in various ways but my understanding is that the trusted publisher mode is preferred.  Instructions for the 'authorization' setup are provided at https://docs.pypi.org/trusted-publishers/adding-a-publisher/.

Draft for:
- [x] identifying the preferred method for triggering a publish to PyPI
- [x] implementing the proper condition to replace the presently hard coded `if: false`
- [x] https://github.com/miniupnp/miniupnp/pull/735