### PR TITLE
update pip for wheel build

### DIFF
--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -176,6 +176,10 @@ jobs:
         with:
           directories: ${{ steps.create-venv.outputs.activate-venv-directories }}
 
+      - name: Update pip
+        run: |
+          python -m pip install --upgrade pip
+
       - name: Copy out miniupnpc
         run: |
           cp -RLv cloned/miniupnpc source


### PR DESCRIPTION
This avoids automatic GHA warnings such as shown in the annotations at https://github.com/miniupnp/miniupnp/actions/runs/8257740388?pr=717.  Except that, as it turns out, that specific error comes out of the https://github.com/actions/setup-python action.  But still, probably good to be updating pip.
