### PR TITLE
miniupnpd: Fix RemoteHost filtering support not enabled on linux

### DIFF
--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -663,7 +663,7 @@ echo "Please edit config.h for more compilation options."
 
 # define SUPPORT_REMOTEHOST if the FW related code really supports setting
 # a RemoteHost
-if [ \( "$FW" = "netfilter" \) -o \( "$FW" = "pf" \) -o \( "$FW" = "ipfw" \) ] ; then
+if [ \( "$FW" = "nftables" \) -o \( "$FW" = "iptables" \) -o \( "$FW" = "pf" \) -o \( "$FW" = "ipfw" \) ] ; then
 	echo "#define SUPPORT_REMOTEHOST" >> ${CONFIGFILE}
 fi
 


### PR DESCRIPTION
Bug introduced in PR https://github.com/miniupnp/miniupnp/pull/441 in 2.2.0 in 2020