### PR TITLE
miniupnpd: add "ext_ip_require_public" option for lower restrictions

### DIFF
--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -35,6 +35,7 @@ static const struct {
 	{ UPNPEXT_IFNAME6, "ext_ifname6" },
 #endif
 	{ UPNPEXT_IP,	"ext_ip" },
+	{ UPNPEXT_IP_REQUIRE_PUBLIC, "ext_ip_require_public" },
 	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
 	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
 	{ UPNPEXT_STUN_PORT, "ext_stun_port" },

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -21,6 +21,7 @@ enum upnpconfigoptions {
 	UPNPEXT_IFNAME6,		/* ext_ifname6 */
 #endif
 	UPNPEXT_IP,				/* ext_ip */
+	UPNPEXT_IP_REQUIRE_PUBLIC,	/* ext_ip_require_public */
 	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
 	UPNPEXT_STUN_HOST,		/* ext_stun_host */
 	UPNPEXT_STUN_PORT,		/* ext_stun_port */

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -87,6 +87,8 @@ extern int runtime_flags;
 
 #define PERFORMSTUNMASK    0x1000
 
+#define REQUIRE_PUBLIC_EXT_IP	0x2000
+
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)
 #define CLEARFLAG(mask)	runtime_flags &= ~mask

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -347,8 +347,10 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
 				ext_if_name);
 			ext_ip_addr[0] = '\0';
 		} else if (addr_is_reserved(&addr)) {
-			syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);
-			ext_ip_addr[0] = '\0';
+			if (GETFLAG(REQUIRE_PUBLIC_EXT_IP)) {
+				syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);
+				ext_ip_addr[0] = '\0';
+			}
 		}
 	}
 #else


### PR DESCRIPTION
```
Some devices may have private IP address but still receive all external
traffic. In such situations forwarding is still possible and UPnP may be
usable for adding ports mappings.

This case is common with some ISPs that provide they own routers with no
bridge mode support. Users wanting to use their own routers usually just
setup DMZ to redirect all external traffic to their own router.

So far miniupnpd didn't allow adding mappings in such cases. This change
allows modifying that default behaviour using:
ext_ip_require_public=no
```