### PR TITLE
miniupnpc: bump CMake version to 3.14

### DIFF
--- a/miniupnpc/CMakeLists.txt
+++ b/miniupnpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project (miniupnpc
          VERSION 2.2.7


### PR DESCRIPTION
The `TYPE` argument for `install(FILES)` is added in CMake 3.14.

https://github.com/miniupnp/miniupnp/blob/ae311e4b84e3dc3cbc9a6559774f2109705967ac/miniupnpc/CMakeLists.txt#L313-L315

https://cmake.org/cmake/help/latest/release/3.14.html
https://cmake.org/cmake/help/latest/command/install.html#files