### PR TITLE
Fix/standardise SOAP/HTTP headers

### DIFF
--- a/minissdpd/minissdpd.c
+++ b/minissdpd/minissdpd.c
@@ -472,7 +472,7 @@ SendSSDPMSEARCHResponse(int s, const struct sockaddr * sockname,
 	 *
 	 * have a look at the document "UPnP Device Architecture v1.1 */
 	l = snprintf(buf, sizeof(buf), "HTTP/1.1 200 OK\r\n"
-		"CACHE-CONTROL: max-age=120\r\n"
+		"CACHE-CONTROL: max-age=1800\r\n"
 		/*"DATE: ...\r\n"*/
 		"ST: %.*s\r\n"
 		"USN: %s\r\n"

--- a/miniupnpc-async/miniupnpc-async.c
+++ b/miniupnpc-async/miniupnpc-async.c
@@ -399,7 +399,7 @@ static int upnpc_send_request(upnpc_device_t * p)
 	ssize_t n;
 	static const char reqfmt[] = "GET %s HTTP/1.1\r\n"
 		"Host: %s:%hu\r\n"
-		"Connection: Close\r\n"
+		"Connection: close\r\n"
 		"User-Agent: OS/version UPnP/1.1 MiniUPnPc-async/2.2\r\n"
 		"\r\n";
 
@@ -693,9 +693,7 @@ static int upnpc_build_soap_request(upnpc_device_t * p, const char * url,
 		"Content-Length: %d\r\n"
 		"Content-Type: text/xml charset=\"utf-8\"\r\n"
 		"SOAPAction: \"%s#%s\"\r\n"
-		"Connection: Close\r\n"
-		"Cache-Control: no-cache\r\n"	/* ??? */
-		"Pragma: no-cache\r\n"
+		"Connection: close\r\n"
 		"\r\n"
 		"%s";
 	char hostname[MAXHOSTNAMELEN+1];

--- a/miniupnpc-libevent/miniupnpc-libevent.c
+++ b/miniupnpc-libevent/miniupnpc-libevent.c
@@ -646,8 +646,6 @@ static int upnpc_send_soap_request(upnpc_device_t * p, const char * url,
 	evhttp_add_header(headers, "SOAPAction", action);
 	evhttp_add_header(headers, "Content-Type", "text/xml; charset=\"utf-8\"");
 	/*evhttp_add_header(headers, "User-Agent", "OS/version UPnP/1.1 MiniUPnPc-libevent/2.2");*/
-	/*evhttp_add_header(headers, "Cache-Control", "no-cache");*/
-	/*evhttp_add_header(headers, "Pragma", "no-cache");*/
 	evbuffer_add(buffer, body, body_len);
 	evhttp_make_request(p->soap_conn, req, EVHTTP_REQ_POST, path);
 	free(body);

--- a/miniupnpc/src/minisoap.c
+++ b/miniupnpc/src/minisoap.c
@@ -83,7 +83,7 @@ int soapPostSubmit(SOCKET fd,
 	 * Using HTTP/1.1 means we need to support chunked transfer-encoding :
 	 * When using HTTP/1.1, the router "BiPAC 7404VNOX" always use chunked
 	 * transfer encoding. */
-    /* Connection: Close is normally there only in HTTP/1.1 but who knows */
+    /* Connection: close is normally there only in HTTP/1.1 but who knows */
 	portstr[0] = '\0';
 	if(port != 80)
 		snprintf(portstr, sizeof(portstr), ":%hu", port);
@@ -98,9 +98,7 @@ int soapPostSubmit(SOCKET fd,
 					   "Content-Type: text/xml; charset=\"utf-8\"\r\n"
 #endif
 					   "SOAPAction: \"%s\"\r\n"
-					   "Connection: Close\r\n"
-					   "Cache-Control: no-cache\r\n"	/* ??? */
-					   "Pragma: no-cache\r\n"
+					   "Connection: close\r\n"
 					   "\r\n",
 					   url, httpversion, host, portstr, bodysize, action);
 	if ((unsigned int)headerssize >= sizeof(headerbuf))

--- a/miniupnpc/src/miniwget.c
+++ b/miniupnpc/src/miniwget.c
@@ -443,7 +443,7 @@ miniwget3(const char * host,
 	len = snprintf(buf, sizeof(buf),
                  "GET %s HTTP/%s\r\n"
 			     "Host: %s:%d\r\n"
-				 "Connection: Close\r\n"
+				 "Connection: close\r\n"
 				 "User-Agent: " OS_STRING " " UPNP_VERSION_STRING " MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
 
 				 "\r\n",

--- a/miniupnpd/upnpevents.c
+++ b/miniupnpd/upnpevents.c
@@ -408,7 +408,6 @@ static void upnp_event_prepare(struct upnp_event_notify * obj)
 		"SID: %s\r\n"
 		"SEQ: %u\r\n"
 		"Connection: close\r\n"
-		"Cache-Control: no-cache\r\n"
 		"\r\n"
 		"%.*s\r\n";
 	char * xml;


### PR DESCRIPTION
- Complete 53d4cdd as it only applies to miniupnpd
- Remove `Pragma: no-cache` (standard in HTTP 1.0) and `Cache-Control: no-cache` request headers as they are not used in the UPnP IGD standards and are not implemented in other clients and standardise the `Connection` header