### PR TITLE
miniupnpd: Increase port map description length limit to 255

### DIFF
--- a/miniupnpd/upnpredirect.c
+++ b/miniupnpd/upnpredirect.c
@@ -201,7 +201,7 @@ int reload_from_lease_file()
 #ifndef LEASEFILE_USE_REMAINING_TIME
 	time_t current_unix_time;
 #endif
-	char line[128];
+	char line[300];
 	int r;
 
 	if(!lease_file) return -1;

--- a/miniupnpd/upnpreplyparse.h
+++ b/miniupnpd/upnpreplyparse.h
@@ -25,7 +25,7 @@ struct NameValue {
 	/*! \brief name */
 	char name[64];
 	/*! \brief character value */
-	char value[128];
+	char value[256];
 };
 
 /*! \brief data structure for parsing */

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -790,7 +790,7 @@ GetSpecificPortMappingEntry(struct upnphttp * h, const char * action, const char
 	const char * r_host, * ext_port, * protocol;
 	unsigned short eport, iport;
 	char int_ip[32];
-	char desc[64];
+	char desc[256];
 	unsigned int leaseduration = 0;
 
 	ParseNameValue(h->req_buf + h->req_contentoff, h->req_contentlen, &data);
@@ -1069,7 +1069,7 @@ GetGenericPortMappingEntry(struct upnphttp * h, const char * action, const char 
 	const char * m_index;
 	char * endptr;
 	char protocol[8], iaddr[32];
-	char desc[64];
+	char desc[256];
 	char rhost[40];
 	unsigned int leaseduration = 0;
 	struct NameValueParserData data;
@@ -1169,7 +1169,7 @@ GetListOfPortMappings(struct upnphttp * h, const char * action, const char * ns)
 	int r = -1;
 	unsigned short iport;
 	char int_ip[32];
-	char desc[64];
+	char desc[256];
 	char rhost[64];
 	unsigned int leaseduration = 0;
 


### PR DESCRIPTION
- Same limit as the original Linksys implementation
- Remove the currently inconsistent length limit of 76 for GetGenericPortMappingEntry/GetSpecificPortMappingEntry and 64 for GetListOfPortMappings (IGDv2)
- No longer truncate description to 127 and 89 on daemon restarts, with lease file
- When using pf firewall backend, 63 (pf label) limit remains

The maximum length is not defined in the UPnP IGD standards. The built-in Windows client allows any description length (>20k tested). The PCP description option standard (not implemented) has a length limit of 1016. Other limits: iptables/nftables comments are limited to 256/128 (not used).