### PR TITLE
Complete proposed changes

### DIFF
--- a/miniupnpc-async/miniupnpc-async.c
+++ b/miniupnpc-async/miniupnpc-async.c
@@ -694,7 +694,6 @@ static int upnpc_build_soap_request(upnpc_device_t * p, const char * url,
 		"Content-Type: text/xml charset=\"utf-8\"\r\n"
 		"SOAPAction: \"%s#%s\"\r\n"
 		"Connection: close\r\n"
-		"Cache-Control: no-cache\r\n"	/* ??? */
 		"\r\n"
 		"%s";
 	char hostname[MAXHOSTNAMELEN+1];

--- a/miniupnpc-libevent/miniupnpc-libevent.c
+++ b/miniupnpc-libevent/miniupnpc-libevent.c
@@ -646,7 +646,6 @@ static int upnpc_send_soap_request(upnpc_device_t * p, const char * url,
 	evhttp_add_header(headers, "SOAPAction", action);
 	evhttp_add_header(headers, "Content-Type", "text/xml; charset=\"utf-8\"");
 	/*evhttp_add_header(headers, "User-Agent", "OS/version UPnP/1.1 MiniUPnPc-libevent/2.2");*/
-	/*evhttp_add_header(headers, "Cache-Control", "no-cache");*/
 	evbuffer_add(buffer, body, body_len);
 	evhttp_make_request(p->soap_conn, req, EVHTTP_REQ_POST, path);
 	free(body);

--- a/miniupnpc/src/upnpc.c
+++ b/miniupnpc/src/upnpc.c
@@ -569,35 +569,34 @@ RemovePinhole(struct UPNPUrls * urls,
 
 static void usage(FILE * out, const char * argv0) {
 	fprintf(out, "Usage:\n");
-	fprintf(out, "  %s [options] -a ip port external_port protocol [duration] [remote host]\n    Add port mapping\n", argv0);
-	fprintf(out, "  %s [options] -r port1 [external_port1] protocol1 [port2 [external_port2] protocol2] [...]\n    Add multiple port mappings to the current host\n", argv0);
-	fprintf(out, "  %s [options] -d external_port protocol [remote host]\n    Delete port redirection\n", argv0);
-	fprintf(out, "  %s [options] -f external_port1 protocol1 [external_port2 protocol2] [...]\n    Delete multiple port redirections\n", argv0);
+	fprintf(out, "  %s [options] -a int_ipv4 int_port ext_port protocol [duration] [remote_host]\n    Add port map\n", argv0);
+	fprintf(out, "  %s [options] -r int_port1 [ext_port1] protocol1 [int_port2 [ext_port2] protocol2] ...\n    Add multiple port maps to this device\n", argv0);
+	fprintf(out, "  %s [options] -d ext_port protocol [remote_host]\n    Delete port map\n", argv0);
+	fprintf(out, "  %s [options] -f ext_port1 protocol1 [ext_port2 protocol2] ...\n    Delete multiple port maps\n", argv0);
 	fprintf(out, "  %s [options] -s\n    Get Connection status\n", argv0);
-	fprintf(out, "  %s [options] -l\n    List redirections\n", argv0);
-	fprintf(out, "  %s [options] -L\n    List redirections (using GetListOfPortMappings (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -n ip port external_port protocol [duration] [remote host]\n    Add (any) port mapping allowing IGD to use alternative external_port (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -N external_port_start external_port_end protocol [manage]\n    Delete range of port mappings (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -A remote_ip remote_port internal_ip internal_port protocol lease_time\n    Add Pinhole (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -U uniqueID new_lease_time\n    Update Pinhole (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -C uniqueID\n    Check if Pinhole is Working (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -K uniqueID\n    Get Number of packets going through the rule (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -D uniqueID\n    Delete Pinhole (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -S\n    Get Firewall status (for IGD:2 only)\n", argv0);
-	fprintf(out, "  %s [options] -G remote_ip remote_port internal_ip internal_port protocol\n    Get Outbound Pinhole Timeout (for IGD:2 only)\n", argv0);
+	fprintf(out, "  %s [options] -l\n    List port maps\n", argv0);
+	fprintf(out, "  %s [options] -L\n    List port maps (using GetListOfPortMappings, IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -n int_ipv4 int_port ext_port protocol [duration] [remote_host]\n    Add (any) port map allowing IGD to use alternative ext port (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -N ext_port_start ext_port_end protocol [manage]\n    Delete range of port maps (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -A remote_host remote_port ipv6 port protocol lease_time\n    Add Pinhole (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -U uniqueID new_lease_time\n    Update Pinhole (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -C uniqueID\n    Check if Pinhole is Working (optional in IGDv2)\n", argv0);
+	fprintf(out, "  %s [options] -K uniqueID\n    Get Number of packets going through the pinhole (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -D uniqueID\n    Delete Pinhole (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -S\n    Get Firewall status (IGDv2 only)\n", argv0);
+	fprintf(out, "  %s [options] -G remote_host remote_port ipv6 port protocol\n    Get Outbound Pinhole Timeout (optional in IGDv2)\n", argv0);
 	fprintf(out, "  %s [options] -P\n    Get Presentation URL\n", argv0);
-	fprintf(out, "\nNotes:\n");
-	fprintf(out, "  protocol is UDP or TCP.\n");
-	fprintf(out, "  Use \"\" for any remote_host and 0 for any remote_port.\n");
-	fprintf(out, "  @ can be used in option -a, -n, -A and -G to represent local LAN address.\n");
-	fprintf(out, "\nOptions:\n");
-	fprintf(out, "  -e description : set description for port mapping.\n");
+	fprintf(out, "Notes:\n");
+	fprintf(out, "  Protocol can be TCP or UDP. Use \"\" for any remote host and 0 for any remote port.\n");
+	fprintf(out, "  @ can be used in option -a, -n, -A and -G to represent int IP address of this device.\n");
+	fprintf(out, "Options:\n");
+	fprintf(out, "  -e description : set description for IPv4 port map.\n");
 	fprintf(out, "  -6 : use IPv6 instead of IPv4.\n");
 	fprintf(out, "  -u URL : bypass discovery process by providing the XML root description URL.\n");
-	fprintf(out, "  -m address/interface : provide IPv4 address or interface name (IPv4 or IPv6) to use for sending SSDP multicast packets.\n");
+	fprintf(out, "  -m interface/address : set interface name (IPv4/IPv6) or IPv4 address for sending SSDP multicast.\n");
 	fprintf(out, "  -z localport : SSDP packets local (source) port (1024-65535).\n");
 	fprintf(out, "  -p path : use this path for MiniSSDPd socket.\n");
-	fprintf(out, "  -t ttl : set multicast TTL. Default value is 2.\n");
+	fprintf(out, "  -t TTL : set multicast TTL. Default value is 2 (UDA 1.1).\n");
 	fprintf(out, "  -i : ignore errors and try to use also disconnected IGD or non-IGD device.\n");
 }
 
@@ -631,9 +630,8 @@ int main(int argc, char ** argv)
 		return -1;
 	}
 #endif
-	printf("upnpc: miniupnpc library test client, version %s.\n", MINIUPNPC_VERSION_STRING);
-	printf(" (c) 2005-2026 Thomas Bernard.\n");
-	printf("More information at https://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/\n\n");
+	printf("upnpc: MiniUPnP IGD library test client version %s. (c) 2005-2026 Thomas Bernard.\n", MINIUPNPC_VERSION_STRING);
+	printf("More information at https://miniupnp.tuxfamily.org/ or http://miniupnp.free.fr/\n");
 
 	/* command line processing */
 	for(i=1; i<argc; i++)

--- a/miniupnpd/Makefile.bsd
+++ b/miniupnpd/Makefile.bsd
@@ -156,8 +156,8 @@ install:	miniupnpd
 	$(INSTALL) -d $(DESTDIR)$(INSTALLBINDIR)
 	$(INSTALL) -m 755 miniupnpd $(DESTDIR)$(INSTALLBINDIR)
 	$(INSTALL) -d $(DESTDIR)$(INSTALLETCDIR)
-	$(INSTALL) -b miniupnpd.conf $(DESTDIR)$(INSTALLETCDIR)/miniupnpd.conf.sample
-	sed -i '' -e "s/^uuid=[-0-9a-fA-F]*/uuid=`$(UUIDBIN)`/" $(DESTDIR)$(INSTALLETCDIR)/miniupnpd.conf.sample
+	$(INSTALL) -b miniupnpd.conf $(DESTDIR)$(INSTALLETCDIR)/miniupnpd.conf
+	sed -i '' -e "s/^uuid=[-0-9a-fA-F]*/uuid=`$(UUIDBIN)`/" $(DESTDIR)$(INSTALLETCDIR)/miniupnpd.conf
 	$(INSTALL) -d $(DESTDIR)$(INSTALLMANDIR)/man8
 	$(INSTALL) -m 644 $(SRCDIR)/miniupnpd.8 $(DESTDIR)$(INSTALLMANDIR)/man8/miniupnpd.8
 

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -147,7 +147,7 @@ system_uptime=yes
 
 # Notify interval in seconds. default is 900 seconds.
 # As advised in the standard, announcement have a lifetime double of this value.
-notify_interval=900
+#notify_interval=900
 
 # Unused rules cleaning.
 # never remove any rule before this threshold for the number
@@ -180,8 +180,8 @@ uuid=00000000-0000-0000-0000-000000000000
 
 # Daemon's serial and model number when reporting to clients
 # (in XML description)
-#serial=12345678
-#model_number=1
+#serial=
+#model_number=
 
 # If compiled with IGD_V2 defined, force reporting IGDv1 in rootDesc (default
 # is no)

--- a/miniupnpd/upnpdescstrings.h
+++ b/miniupnpd/upnpdescstrings.h
@@ -17,7 +17,7 @@
 #define ROOTDEV_MANUFACTURER		OS_NAME
 #define ROOTDEV_MANUFACTURERURL		OS_URL
 #define ROOTDEV_MODELNAME			OS_NAME " router"
-#define ROOTDEV_MODELDESCRIPTION	OS_NAME " with MiniUPnPd version " MINIUPNPD_VERSION " router"
+#define ROOTDEV_MODELDESCRIPTION	OS_NAME " router"
 #define ROOTDEV_MODELURL			OS_URL
 
 #define WANDEV_FRIENDLYNAME			"WANDevice"
@@ -27,7 +27,7 @@
 #define WANDEV_MODELDESCRIPTION		"MiniUPnP daemon version " MINIUPNPD_VERSION
 #define WANDEV_MODELNUMBER			MINIUPNPD_DATE
 #define WANDEV_MODELURL				"https://miniupnp.tuxfamily.org/"
-#define WANDEV_UPC					"000000000000"
+#define WANDEV_UPC					""
 /* UPC is 12 digit (barcode) */
 
 #define WANCDEV_FRIENDLYNAME		"WANConnectionDevice"
@@ -37,7 +37,7 @@
 #define WANCDEV_MODELDESCRIPTION	"MiniUPnP daemon version " MINIUPNPD_VERSION
 #define WANCDEV_MODELNUMBER			MINIUPNPD_DATE
 #define WANCDEV_MODELURL			"https://miniupnp.tuxfamily.org/"
-#define WANCDEV_UPC					"000000000000"
+#define WANCDEV_UPC					""
 /* UPC is 12 digit (barcode) */
 
 #endif

--- a/miniupnpd/upnpevents.c
+++ b/miniupnpd/upnpevents.c
@@ -421,7 +421,6 @@ static void upnp_event_prepare(struct upnp_event_notify * obj)
 		"SID: %s\r\n"
 		"SEQ: %u\r\n"
 		"Connection: close\r\n"
-		"Cache-Control: no-cache\r\n"
 		"\r\n"
 		"%.*s\r\n";
 	char * xml;

--- a/miniupnpd/upnpglobalvars.c
+++ b/miniupnpd/upnpglobalvars.c
@@ -65,9 +65,9 @@ const char * pidfilename = "/var/run/miniupnpd.pid";
 char uuidvalue_igd[] = "uuid:00000000-0000-0000-0000-000000000000";
 char uuidvalue_wan[] = "uuid:00000000-0000-0000-0000-000000000000";
 char uuidvalue_wcd[] = "uuid:00000000-0000-0000-0000-000000000000";
-char serialnumber[SERIALNUMBER_MAX_LEN] = "00000000";
+char serialnumber[SERIALNUMBER_MAX_LEN] = "";
 
-char modelnumber[MODELNUMBER_MAX_LEN] = "1";
+char modelnumber[MODELNUMBER_MAX_LEN] = "";
 
 /* presentation url :
  * http://nnn.nnn.nnn.nnn:ppppp/  => max 30 bytes including terminating 0 */


### PR DESCRIPTION
The following PRs/issues have not been fully adopted or parts have been overlooked. The following PR tries to fix this.

- Complete: **option enable_natpmp => enable_pcp_pmp** 02da705
  Remove old name still present in documentation/comments
- Complete: #681
  Fix partial help rewrite (remove "redirect", currently more confusing). Add note about optional IGDv2 commands and IPv4/IPv6. Minor wording update/normalise, reduce line width/breaks.
- Complete: #698
  Comment `notify_interval` in configuration, as same value as default and fix help.
- Complete: #709
  Empty dummy values from advertised informal `serialNumber` and `UPC` as IMHO it looks unfinished/unclean not like a long existing project. Remove the change in the root device `modelDescription` to keep the root device white labelled as before.
- Complete: #745
  Remove the `Cache-Control: no-cache` header as it is not used in the IGD specification and by other clients and test tool. Only used in HTTP when using a cache/proxy, which is not possible with IGD. Normally only used in HTTP for GET and not for POST, but in miniupnpc only for POST and not for GET requests. No routers known to need this.