### PR TITLE
miniupnpd: Improve configure - withdrawn

### DIFF
--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -870,8 +870,8 @@ echo "#ifdef IGD_V2" >> ${CONFIGFILE}
 echo "/* Enable DeviceProtection service (IGDv2) - incomplete implementation */" >> ${CONFIGFILE}
 echo "/*#define ENABLE_DP_SERVICE*/" >> ${CONFIGFILE}
 echo "/*#define ENABLE_HTTPS*/" >> ${CONFIGFILE}
-echo "/*#define HTTPS_CERTFILE \"/path/to/certificate.pem\"*/" >> ${CONFIGFILE}
-echo "/*#define HTTPS_KEYFILE \"/path/to/private.key\"*/" >> ${CONFIGFILE}
+echo "/*#define HTTPS_CERTFILE \"/etc/miniupnpd/https-certificate.pem\"*/" >> ${CONFIGFILE}
+echo "/*#define HTTPS_KEYFILE \"/etc/miniupnpd/https-privatekey.pem\"*/" >> ${CONFIGFILE}
 echo "" >> ${CONFIGFILE}
 echo "/* Enable WANIPv6FirewallControl service (IGDv2). needs IPv6 */" >> ${CONFIGFILE}
 echo "#ifdef ENABLE_IPV6" >> ${CONFIGFILE}

--- a/miniupnpd/upnphttp.c
+++ b/miniupnpd/upnphttp.c
@@ -39,13 +39,6 @@
 #include <openssl/conf.h>
 static SSL_CTX *ssl_ctx = NULL;
 
-#ifndef HTTPS_CERTFILE
-#define HTTPS_CERTFILE "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-#endif
-#ifndef HTTPS_KEYFILE
-#define HTTPS_KEYFILE "/etc/ssl/private/ssl-cert-snakeoil.key"
-#endif
-
 static void
 syslogsslerr(void)
 {


### PR DESCRIPTION
- Use `/etc/os-release` to detect linux dists in configure which also provides `HOME_URL` and is available on most linux distributions, FreeBSD and others
Some distributions have a longer name in `os-release` than with `lsb_release`, so this is just a fallback at the moment, but it allows many lines in configure to be removed later if the longer names are OK.
- Fix configure linux if `--host-os-version` not set to kernelver by setting `HAVE_IP_MREQN=1` by default, this requires linux kernel >= 2.4 from 2001
- miniupnpd: Better default cert file path for experimental HTTPS support