### PR TITLE
enable miniupnpc wheel builds on windows

### DIFF
--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -136,8 +136,6 @@ jobs:
               matrix: windows
             arch:
               matrix: universal2
-          - os:  # excluding windows entirely as that is presently handled in AppVeyor
-              matrix: windows
           - os:
               matrix: windows
             arch:


### PR DESCRIPTION
Presently this is just for comparison.  The existing uploaded wheels seem to be missing the actually dll.

![image](https://github.com/miniupnp/miniupnp/assets/543719/db1b2e29-9d4e-40a7-9b55-de123f46c13f)
