### PR TITLE
include `miniupnpc.dll` when building for Windows

### DIFF
--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -218,7 +218,6 @@ jobs:
           mingw32-make -f Makefile.mingw CC=gcc
           python -m pip install setuptools wheel
           mingw32-make -f Makefile.mingw pythonmodule PYTHON=python
-          7z a dist/*.whl miniupnpc.dll
           mkdir ../dist
           cp dist/*.whl ../dist
 

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -137,7 +137,7 @@ jobs:
             arch:
               matrix: universal2
           - os:  # excluding windows entirely as that is presently handled in AppVeyor
-              matrix: windows
+              matrix: windows-temporarily-allow-windows-here
           - os:
               matrix: windows
             arch:

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -137,7 +137,7 @@ jobs:
             arch:
               matrix: universal2
           - os:  # excluding windows entirely as that is presently handled in AppVeyor
-              matrix: windows-temporarily-allow-windows-here
+              matrix: windows
           - os:
               matrix: windows
             arch:

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,7 +88,7 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	WHEEL_PATH="dist*.whl"
+	WHEEL_PATH="dist/*.whl"
 	mv "$WHEEL_PATH" "$WHEEL_PATH".zip
 	powershell Compress-Archive -update miniupnpc.dll "$WHEEL_PATH".zip
 	mv "$WHEEL_PATH".zip "$WHEEL_PATH"

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,12 +88,7 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	ls -l dist/*
-	WHEEL_PATH=$$(ls dist/*.whl)
-	echo wheel path: "$$WHEEL_PATH"
-	mv "$$WHEEL_PATH" "$$WHEEL_PATH".zip
-	powershell Compress-Archive -update miniupnpc.dll "$$WHEEL_PATH".zip
-	mv "$$WHEEL_PATH".zip "$$WHEEL_PATH"
+	for WHEEL_PATH in dist/*.whl; do mv "$$WHEEL_PATH" "$$WHEEL_PATH".zip; powershell Compress-Archive -update miniupnpc.dll "$$WHEEL_PATH".zip; mv "$$WHEEL_PATH".zip "$$WHEEL_PATH"; done
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,6 +88,7 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
+        7z a dist/*.whl miniupnpc.dll
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,7 +88,7 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-        7z a dist/*.whl miniupnpc.dll
+	7z a dist/*.whl miniupnpc.dll
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,7 +88,7 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	7z a dist/*.whl miniupnpc.dll
+	powershell Compress-Archive -update miniupnpc.dll dist/*.whl
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,7 +88,9 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	WHEEL_PATH="dist/*.whl"
+	ls -l dist/*
+	WHEEL_PATH=$$(ls dist/*.whl)
+	echo wheel path: "$$WHEEL_PATH"
 	mv "$$WHEEL_PATH" "$$WHEEL_PATH".zip
 	powershell Compress-Archive -update miniupnpc.dll "$$WHEEL_PATH".zip
 	mv "$$WHEEL_PATH".zip "$$WHEEL_PATH"

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -89,9 +89,9 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
 	WHEEL_PATH="dist/*.whl"
-	mv "$WHEEL_PATH" "$WHEEL_PATH".zip
-	powershell Compress-Archive -update miniupnpc.dll "$WHEEL_PATH".zip
-	mv "$WHEEL_PATH".zip "$WHEEL_PATH"
+	mv "$$WHEEL_PATH" "$$WHEEL_PATH".zip
+	powershell Compress-Archive -update miniupnpc.dll "$$WHEEL_PATH".zip
+	mv "$$WHEEL_PATH".zip "$$WHEEL_PATH"
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,7 +88,9 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	powershell Compress-Archive -update miniupnpc.dll dist/*.whl
+	rename dist/*.whl dist/*.whl.zip
+	powershell Compress-Archive -update miniupnpc.dll dist/*.whl.zip
+	rename dist/*.whl.zip dist/*.whl
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \

--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -88,9 +88,10 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py install --skip-build
 	$(PYTHON) setupmingw32.py sdist
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
-	rename dist/*.whl dist/*.whl.zip
-	powershell Compress-Archive -update miniupnpc.dll dist/*.whl.zip
-	rename dist/*.whl.zip dist/*.whl
+	WHEEL_PATH="dist*.whl"
+	mv "$WHEEL_PATH" "$WHEEL_PATH".zip
+	powershell Compress-Archive -update miniupnpc.dll "$WHEEL_PATH".zip
+	mv "$WHEEL_PATH".zip "$WHEEL_PATH"
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
 	$(DLLWRAP) -k --driver-name $(CC) \


### PR DESCRIPTION
This is still hacky, but it 1) applies the hack to all builds using the makefile and 2) moves the hack one step closer to where the proper fix is.  I would do the proper fix but I don't offhand know the right option to set in `setup.py` (or `setupmingw32.py` in this case) to get the `.dll` included in the wheel (and not the sdist).  So, baby steps.

Draft for:
- [x] not using 7z
- [x] re-disable GitHub Actions Windows wheel builds