### PR TITLE
miniupnpd: Rename config option `force_igd_desc_v1` to `upnp_igd_compat`

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1467,10 +1467,10 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				break;
 #ifdef IGD_V2
 			case UPNPFORCEIGDDESCV1:
-				if (strcmp(ary_options[i].value, "yes") == 0)
+				if ((strcmp(ary_options[i].value, "igdv1") == 0) || (strcmp(ary_options[i].value, "yes") == 0))
 					SETFLAG(FORCEIGDDESCV1MASK);
-				else if (strcmp(ary_options[i].value, "no") != 0 ) {
-					INIT_PRINT_ERR("force_igd_desc_v1 can only be yes or no\n");
+				else if ((strcmp(ary_options[i].value, "igdv2") != 0 ) && (strcmp(ary_options[i].value, "no") != 0 )) {
+					INIT_PRINT_ERR("upnp_igd_compat (or force_igd_desc_v1) can only be igdv1/igdv2 (or yes/no)\n");
 					return 1;
 				}
 				break;

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -174,9 +174,12 @@ uuid=00000000-0000-0000-0000-000000000000
 #serial=12345678
 #model_number=1
 
-# If compiled with IGD_V2 defined, force reporting IGDv1 in rootDesc (default
-# is no)
-#force_igd_desc_v1=no
+# UPnP IGD compatibility mode (default igdv2)
+# Available modes: igdv1 (IPv4-only) and igdv2
+# Some IGDv1 clients still incompatible with IGDv2 routers.
+# The incompatible Microsoft IGDv1 client always gets IGDv1.
+# IGDv1: If compiled with IGD_V2 defined, force reporting IGDv1 in rootDesc
+#upnp_igd_compat=igdv1
 
 # UPnP permission rules (also enforced for NAT-PMP and PCP) for IPv4
 # (allow|deny) (external port range) IP/mask (internal port range) (optional regex filter)

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -101,6 +101,7 @@ static const struct {
 #endif
 #endif
 #ifdef IGD_V2
+	{ UPNPFORCEIGDDESCV1, "upnp_igd_compat"},
 	{ UPNPFORCEIGDDESCV1, "force_igd_desc_v1"},
 #endif
 	{ UPNPMINISSDPDSOCKET, "minissdpdsocket"},


### PR DESCRIPTION
while still accepting the old name (for backword compatibility) and the new values `igdv1`/`ìgdv2` and still keeping `yes`/`no` as accepted. And improve the documentation of the UPnP IGD compatibility mode.

Fixes #760