### PR TITLE
miniupnpd: Small Makefile.bsd, man page fixes and IGD config improvements

### DIFF
--- a/miniupnpd/INSTALL
+++ b/miniupnpd/INSTALL
@@ -173,9 +173,9 @@ allowed, so it is a good practice to have a "catch all" deny permission
 rule at the end of your permission ruleset.
 Sample permission ruleset :
 allow 4662-4672 192.168.1.34/32 4662-4672
-deny 0-65535 192.168.1.34/32 0-65535
+deny 1-65535 192.168.1.34/32 1-65535
 allow 1024-65535 192.168.1.0/24 1024-65535
-deny 0-65535 0.0.0.0/0 0-65535
+deny 1-65535 0.0.0.0/0 1-65535
 With this ruleset, redirections are allowed only for host on the subnet
 192.168.1.0/255.255.255.0 for the ports 1024 or above. There is an exception
 for the host 192.168.1.34 for which only redirections from/to port 4662 to

--- a/miniupnpd/Makefile.bsd
+++ b/miniupnpd/Makefile.bsd
@@ -130,7 +130,7 @@ MANPREFIX ?= $(PREFIX)
 .if $(MANPREFIX) == ""
 MANPREFIX = /usr/share
 .endif
-INSTALLMANDIR = $(MANPREFIX)/man
+INSTALLMANDIR = $(MANPREFIX)/man/man8
 
 all:	$(EXECUTABLES)
 
@@ -153,7 +153,7 @@ install:	miniupnpd genuuid
 	$(INSTALL) -d $(DESTDIR)$(INSTALLETCDIR)
 	$(INSTALL) -b miniupnpd.conf $(DESTDIR)$(INSTALLETCDIR)
 	$(INSTALL) -d $(DESTDIR)$(INSTALLMANDIR)
-	$(INSTALL) -m 644 $(SRCDIR)/miniupnpd.8 $(DESTDIR)$(INSTALLMANDIR)/man8/miniupnpd.8
+	$(INSTALL) -m 644 $(SRCDIR)/miniupnpd.8 $(DESTDIR)$(INSTALLMANDIR)/miniupnpd.8
 
 # genuuid is using the uuid cli tool available under OpenBSD 4.0 in
 # the uuid-1.5.0 package

--- a/miniupnpd/miniupnpd.8
+++ b/miniupnpd/miniupnpd.8
@@ -1,6 +1,6 @@
 .TH MINIUPNPD 8
 .SH NAME
-miniupnpd \- UPnP Internet Gateway Device Daemon
+miniupnpd \- UPnP IGD & PCP/NAT-PMP daemon
 .SH SYNOPSIS
 .B miniupnpd
 .RB [--version]
@@ -11,10 +11,10 @@ miniupnpd \- UPnP Internet Gateway Device Daemon
 .RB [ "\-B \fIdown up" "] [" "\-w \fIurl" "] [" "\-r \fIclean_ruleset_interval" ]
 .RB [ "\-A \fIpermission rule" "] [" "\-b \fIBOOTID" "] [" \-1 ]
 .SH DESCRIPTION
-miniupnpd act as a UPnP Internet Gateway Device. It is designed
+miniupnpd act as a UPnP IGD & PCP/NAT-PMP daemon. It is designed
 to run on the gateway between the internet and a NAT'ed LAN. It provides
-an interface, as defined in the UPnP standard, for enabling
-clients on the LAN to ask for port redirections.
+an interface, as defined in the UPnP IGD & PCP/NAT-PMP standards, for enabling
+clients on the LAN to ask for port maps.
 .SH OPTIONS
 .TP
 .BI \-f " config_file"
@@ -41,11 +41,11 @@ and do not filter out low priority messages.
 .B \-U
 report system uptime instead of daemon uptime to clients.
 .TP
-.B \-S
-sets "secure" mode : clients can only add mappings to their own ip
+.B \-S0
+disable "secure" mode so clients can add mappings to other IPs
 .TP
 .B \-N
-enables NAT-PMP functionality.
+enable PCP/NAT-PMP protocols.
 .TP
 .BI \-u " uuid"
 set the uuid of the UPnP Internet Gateway Device.
@@ -57,8 +57,7 @@ serial number for the UPnP Internet Gateway Device.
 model number for the UPnP Internet Gateway Device.
 .TP
 .BI \-t " notify_interval"
-SSDP notify interval in seconds :
-SSDP announce messages will be broadcasted at this interval.
+SSDP notify interval in seconds. Default is 900 seconds. SSDP announce messages will be broadcasted at this interval.
 .TP
 .BI \-P " pid_filename"
 pid file. default is /var/run/miniupnpd.pid
@@ -78,13 +77,13 @@ use following syntax for permission rules :
 .br
 examples :
   "allow 1024-65535 192.168.1.0/24 1024-65535"
-  "deny 0-65535 0.0.0.0/0 0-65535"
+  "deny 1-65535 0.0.0.0/0 1-65535"
 .TP
 .BI \-b " BOOTID"
 sets the value of BOOTID.UPNP.ORG SSDP header
 .TP
 .B \-1
-force reporting IGDv1 in rootDesc when compiled as IGDv2 *use with care*
+force reporting IGDv1 in rootDesc when compiled as IGDv2
 .SH "SEE ALSO"
 minissdpd(1) miniupnpc(3)
 .SH BUGS

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1465,16 +1465,18 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPMINISSDPDSOCKET:
 				minissdpdsocketpath = ary_options[i].value;
 				break;
-#ifdef IGD_V2
 			case UPNPFORCEIGDDESCV1:
+#ifdef IGD_V2
 				if (strcmp(ary_options[i].value, "yes") == 0)
 					SETFLAG(FORCEIGDDESCV1MASK);
 				else if (strcmp(ary_options[i].value, "no") != 0 ) {
 					INIT_PRINT_ERR("force_igd_desc_v1 can only be yes or no\n");
 					return 1;
 				}
-				break;
+#else
+				syslog(LOG_INFO, "Ignoring force_igd_desc_v1 option as not compiled with IGDv2 support");
 #endif
+				break;
 			default:
 				INIT_PRINT_ERR("Unknown option in file %s\n",
 				        optionsfile);
@@ -1517,11 +1519,13 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			SETFLAG(IPV6DISABLEDMASK);
 			break;
 #endif
-#ifdef IGD_V2
 		case '1':
+#ifdef IGD_V2
 			SETFLAG(FORCEIGDDESCV1MASK);
-			break;
+#else
+			syslog(LOG_INFO, "Ignoring -1 option as not compiled with IGDv2 support");
 #endif
+			break;
 		case 'b':
 			if(i+1 < argc) {
 				upnp_bootid = (unsigned int)strtoul(argv[++i], NULL, 10);

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -2075,14 +2075,14 @@ print_usage:
 #if defined(USE_PF) || defined(USE_IPF)
 			"\t-L sets packet log in pf and ipf on.\n"
 #endif
-			"\t-S0 disable \"secure\" mode so clients can add mappings to other ips\n"
+			"\t-S0 disable \"secure\" mode so clients can add mappings to other IPs\n"
 			"\t-U causes miniupnpd to report system uptime instead "
 			"of daemon uptime.\n"
 #ifdef ENABLE_NATPMP
 #ifdef ENABLE_PCP
-			"\t-N enables NAT-PMP and PCP functionality.\n"
+			"\t-N enable PCP/NAT-PMP protocols.\n"
 #else
-			"\t-N enables NAT-PMP functionality.\n"
+			"\t-N enable NAT-PMP protocol.\n"
 #endif
 #endif
 			"\t-B sets bitrates reported by daemon in bits per second.\n"
@@ -2099,10 +2099,10 @@ print_usage:
 			"\t  (allow|deny) (external port range) ip/mask (internal port range)\n"
 			"\texamples :\n"
 			"\t  \"allow 1024-65535 192.168.1.0/24 1024-65535\"\n"
-			"\t  \"deny 0-65535 0.0.0.0/0 0-65535\"\n"
+			"\t  \"deny 1-65535 0.0.0.0/0 1-65535\"\n"
 			"\t-b sets the value of BOOTID.UPNP.ORG SSDP header\n"
 #ifdef IGD_V2
-			"\t-1 force reporting IGDv1 in rootDesc *use with care*\n"
+			"\t-1 force reporting IGDv1 in rootDesc\n"
 #endif
 			"\t-v enables LOG_INFO messages, -vv LOG_DEBUG as well (default with -d)\n"
 			"\t-h / --help prints this help and quits.\n"

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -185,7 +185,7 @@ uuid=00000000-0000-0000-0000-000000000000
 # IP/mask format must be nnn.nnn.nnn.nnn/nn
 # Regex support must be enabled at build time : ./configure --regex
 # It is advised to only allow redirection of ports >= 1024
-# and end the rule set with "deny 0-65535 0.0.0.0/0 0-65535"
+# and end the rule set with "deny 1-65535 0.0.0.0/0 1-65535"
 # The following default ruleset allows specific LAN side IP addresses
 # to request only ephemeral ports. It is recommended that users
 # modify the IP ranges to match their own internal networks, and
@@ -197,4 +197,4 @@ allow 1024-65535 192.168.0.0/24 1024-65535
 allow 1024-65535 192.168.1.0/24 1024-65535
 allow 1024-65535 192.168.0.0/23 22
 allow 12345 192.168.7.113/32 54321
-deny 0-65535 0.0.0.0/0 0-65535
+deny 1-65535 0.0.0.0/0 1-65535

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -100,9 +100,7 @@ static const struct {
 	{ UPNPLEASEFILE6, "lease_file6"},
 #endif
 #endif
-#ifdef IGD_V2
 	{ UPNPFORCEIGDDESCV1, "force_igd_desc_v1"},
-#endif
 	{ UPNPMINISSDPDSOCKET, "minissdpdsocket"},
 	{ UPNPSECUREMODE, "secure_mode"}
 };

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -80,9 +80,7 @@ enum upnpconfigoptions {
 #endif
 #endif
 	UPNPMINISSDPDSOCKET,	/* minissdpdsocket */
-#ifdef IGD_V2
 	UPNPFORCEIGDDESCV1,
-#endif
 	UPNPENABLE				/* enable_upnp */
 };
 

--- a/miniupnpd/upnppermissions.h
+++ b/miniupnpd/upnppermissions.h
@@ -20,7 +20,7 @@
 
 /* UPnP permission rule samples:
  * allow 1024-65535 192.168.3.0/24 1024-65535
- * deny 0-65535 192.168.1.125/32 0-65535 */
+ * deny 1-65535 192.168.1.125/32 1-65535 */
 struct upnpperm {
 	enum {UPNPPERM_ALLOW=1, UPNPPERM_DENY=2 } type;
 				/* is it an allow or deny permission rule ? */
@@ -40,7 +40,7 @@ struct upnpperm {
  * line sample :
  *  allow 1024-65535 192.168.3.0/24 1024-65535
  *  allow 22 192.168.4.33/32 22
- *  deny 0-65535 0.0.0.0/0 0-65535 */
+ *  deny 1-65535 0.0.0.0/0 1-65535 */
 int
 read_permission_line(struct upnpperm * perm,
                      char * p);


### PR DESCRIPTION
- Fix Makefile.bsd man dir creation
  Follow Linux makefiles and allow removal of downstream patch in FreeBSD ports
- Fix manual page, harmonise and remove obsolete note
- Allow and ignore UPnP IGD compatibility mode runtime option if compiled without IGDv2 support
  Current behaviour: daemon exits with error 1. This allows pre-configuration of IGDv1 mode (for client compatibility) in a UI frontend (configuration) package, regardless of whether the daemon package is already compiled with IGDv2 support, for smoother/independent updates of separate packages as in e.g. OPNsense/pfSense