### PR TITLE
miniupnpd: Remove broken `Unused rules cleaning` code

### DIFF
--- a/miniupnpd/miniupnpd.8
+++ b/miniupnpd/miniupnpd.8
@@ -68,9 +68,6 @@ download and upload bitrates reported to clients.
 .BI \-w " url"
 presentation url. default is first address on LAN, port 80.
 .TP
-.BI \-r " clean_ruleset_interval"
-(minimum) interval between unused rules cleaning checks.
-.TP
 .BI \-A " permission rule"
 use following syntax for permission rules :
   (allow|deny) (external port range) ip/mask (internal port range)

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -917,9 +917,6 @@ struct runtime_vars {
 	int https_port;	/* HTTPS Port */
 #endif
 	int notify_interval;	/* seconds between SSDP announces. Should be >= 900s */
-	/* unused rules cleaning related variables : */
-	int clean_ruleset_threshold;	/* threshold for removing unused rules */
-	int clean_ruleset_interval;		/* (minimum) interval between checks. 0=disabled */
 #ifdef USE_SYSTEMD
 	int systemd_notify;
 #endif
@@ -1280,7 +1277,7 @@ void print_usage(FILE * out, const char * argv0) {
 #ifdef ENABLE_MANUFACTURER_INFO_CONFIGURATION
 			"[-z fiendly_name]"
 #endif
-			"\n\t\t[-B down up] [-w url] [-r clean_ruleset_interval]\n"
+			"\n\t\t[-B down up] [-w url]\n"
 #ifdef USE_PF
                         "\t\t[-q queue] [-T tag]\n"
 #endif
@@ -1426,8 +1423,6 @@ init(int argc, char * * argv, struct runtime_vars * v)
 	v->https_port = -1;
 #endif
 	v->notify_interval = 900;	/* seconds between SSDP announces */
-	v->clean_ruleset_threshold = 20;
-	v->clean_ruleset_interval = 0;	/* interval between ruleset check. 0=disabled */
 #ifndef DISABLE_CONFIG_FILE
 	/* read options file first since
 	 * command line arguments have final say */
@@ -1598,10 +1593,10 @@ init(int argc, char * * argv, struct runtime_vars * v)
 				modelnumber[MODELNUMBER_MAX_LEN-1] = '\0';
 				break;
 			case UPNPCLEANTHRESHOLD:
-				v->clean_ruleset_threshold = atoi(ary_options[i].value);
+				syslog(LOG_NOTICE, "Ignored option clean_ruleset_threshold, as non-standard/legacy functionality removed");
 				break;
 			case UPNPCLEANINTERVAL:
-				v->clean_ruleset_interval = atoi(ary_options[i].value);
+				syslog(LOG_NOTICE, "Ignored option clean_ruleset_interval, as non-standard/legacy functionality removed");
 				break;
 #ifdef USE_PF
 			case UPNPANCHOR:
@@ -1765,12 +1760,14 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			break;
 		case 'r':
 			if(i+1 < argc) {
-				v->clean_ruleset_interval = atoi(argv[++i]);
+				syslog(LOG_NOTICE, "Ignored option -r, as non-standard/legacy functionality removed");
+				i++;
 			} else {
 				INIT_PRINT_ERR("Option -%c takes one argument.\n", argv[i][1]);
 				goto print_usage;
 			}
 			break;
+
 		case 'u':
 			if(i+1 < argc) {
 				strncpy(uuidvalue_igd+5, argv[++i], strlen(uuidvalue_igd+5) + 1);
@@ -2309,9 +2306,6 @@ main(int argc, char * * argv)
 	struct ctlelem * ectlnext;
 #endif
 	struct runtime_vars v;
-	/* variables used for the unused-rule cleanup process */
-	struct rule_state * rule_list = 0;
-	struct timeval checktime = {0, 0};
 	struct lan_addr_s * lan_addr;
 #ifdef ENABLE_UPNPPINHOLE
 	unsigned int next_pinhole_ts;
@@ -2850,21 +2844,6 @@ main(int argc, char * * argv)
 					timeout.tv_usec = lasttimeofday.tv_usec - timeofday.tv_usec;
 				}
 			}
-		}
-		/* remove unused rules */
-		if( v.clean_ruleset_interval
-		  && (timeofday.tv_sec >= checktime.tv_sec + v.clean_ruleset_interval))
-		{
-			if(rule_list)
-			{
-				remove_unused_rules(rule_list);
-				rule_list = NULL;
-			}
-			else
-			{
-				rule_list = get_upnp_rules_state_list(v.clean_ruleset_threshold);
-			}
-			memcpy(&checktime, &timeofday, sizeof(struct timeval));
 		}
 		/* Remove expired port mappings, based on UPnP IGD LeaseDuration
 		 * or NAT-PMP lifetime) */

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -149,14 +149,6 @@ system_uptime=yes
 # As advised in the standard, announcement have a lifetime double of this value.
 notify_interval=900
 
-# Unused rules cleaning.
-# never remove any rule before this threshold for the number
-# of redirections is exceeded. default to 20
-#clean_ruleset_threshold=10
-# Clean process work interval in seconds. default to 0 (disabled).
-# a 600 seconds (10 minutes) interval makes sense
-clean_ruleset_interval=600
-
 # Log packets in pf (default is no)
 #packet_log=no
 

--- a/miniupnpd/upnpredirect.c
+++ b/miniupnpd/upnpredirect.c
@@ -663,42 +663,6 @@ get_upnp_rules_state_list(int max_rules_number_target)
 	return list;
 }
 
-void
-remove_unused_rules(struct rule_state * list)
-{
-	char ifname[IFNAMSIZ];
-	unsigned short iport;
-	struct rule_state * tmp;
-	u_int64_t packets;
-	u_int64_t bytes;
-	unsigned int timestamp;
-	int n = 0;
-
-	while(list)
-	{
-		/* remove the rule if no traffic has used it */
-		if(get_redirect_rule(ifname, list->eport, list->proto,
-	                         0, 0, &iport, 0, 0, 0, 0, &timestamp,
-		                     &packets, &bytes) >= 0)
-		{
-			if(packets == list->packets && bytes == list->bytes)
-			{
-				syslog(LOG_DEBUG, "removing unused mapping %hu %s : still "
-				       "%" PRIu64 "packets %" PRIu64 "bytes",
-				       list->eport, proto_itoa(list->proto),
-				       packets, bytes);
-				_upnp_delete_redir(list->eport, list->proto);
-				n++;
-			}
-		}
-		tmp = list;
-		list = tmp->next;
-		free(tmp);
-	}
-	if(n>0)
-		syslog(LOG_NOTICE, "removed %d unused rules", n);
-}
-
 /* upnp_get_portmappings_in_range()
  * return a list of all "external" ports for which a port
  * mapping exists */

--- a/miniupnpd/upnpredirect.h
+++ b/miniupnpd/upnpredirect.h
@@ -98,11 +98,6 @@ get_upnp_rules_state_list(int max_rules_number_target);
 int
 upnp_get_portmapping_number_of_entries(void);
 
-/* remove_unused_rules() :
- * also free the list */
-void
-remove_unused_rules(struct rule_state * list);
-
 /* upnp_get_portmappings_in_range()
  * return a list of all "external" ports for which a port
  * mapping exists */


### PR DESCRIPTION
- Remove broken code for `Cleaning unexpired port maps without traffic`, known in the project as `Unused rules cleaning`
- Removed CLI option `-r` and configuration options `clean_ruleset_interval`/`clean_ruleset_threshold` and log a notice if used instead
- This removal should be mentioned in a breaking change in the changelog

Close: #789