### PR TITLE
OpenBSD fix for removal of expired rules & miniupnpd ssdp fixes

### DIFF
--- a/miniupnpd/bsd/getroute.c
+++ b/miniupnpd/bsd/getroute.c
@@ -65,7 +65,7 @@ get_src_for_route_to(const struct sockaddr * dst,
 	rtm.rtm_flags = RTF_UP;
 	rtm.rtm_version = RTM_VERSION;
 	rtm.rtm_seq = 1;
-	rtm.rtm_addrs = RTA_DST | RTA_IFA | RTA_IFP;	/* pass destination address, request source address & interface */
+	rtm.rtm_addrs = RTA_DST;
 	memcpy(m_rtmsg.m_space, dst, l);
 #if !defined(__sun)
 	((struct sockaddr *)m_rtmsg.m_space)->sa_len = l;

--- a/miniupnpd/bsd/getroute.c
+++ b/miniupnpd/bsd/getroute.c
@@ -16,6 +16,9 @@
 #ifdef AF_LINK
 #include <net/if_dl.h>
 #endif
+#ifdef __OpenBSD__
+#include <sys/param.h>
+#endif
 
 #include "config.h"
 #include "../upnputils.h"
@@ -65,7 +68,11 @@ get_src_for_route_to(const struct sockaddr * dst,
 	rtm.rtm_flags = RTF_UP;
 	rtm.rtm_version = RTM_VERSION;
 	rtm.rtm_seq = 1;
+#if defined(OpenBSD) && OpenBSD >= 201911
 	rtm.rtm_addrs = RTA_DST;
+#else
+	rtm.rtm_addrs = RTA_DST | RTA_IFA | RTA_IFP;	/* pass destination address, request source address & interface */
+#endif
 	memcpy(m_rtmsg.m_space, dst, l);
 #if !defined(__sun)
 	((struct sockaddr *)m_rtmsg.m_space)->sa_len = l;

--- a/miniupnpd/minissdp.c
+++ b/miniupnpd/minissdp.c
@@ -220,7 +220,11 @@ OpenAndConfSSDPReceiveSocket(int ipv6)
 #endif /* IP_PKTINFO */
 #if defined(ENABLE_IPV6) && defined(IPV6_RECVPKTINFO)
 	if(ipv6) {
+#ifdef IPPROTO_IPV6
+		if(setsockopt(s, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)) < 0)
+#else
 		if(setsockopt(s, IPPROTO_IP, IPV6_RECVPKTINFO, &on, sizeof(on)) < 0)
+#endif
 		{
 			syslog(LOG_WARNING, "setsockopt(udp, IPV6_RECVPKTINFO): %m");
 		}

--- a/miniupnpd/pf/obsdrdr.c
+++ b/miniupnpd/pf/obsdrdr.c
@@ -1471,11 +1471,13 @@ get_redirect_rule_by_index(int index,
 	}
 #else /* USE_LIBPFCTL */
 	pr.nr = index;
-	if(ioctl(dev, DIOCGETRULE, &pr) < 0)
-	{
-		syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
-		goto error;
-	}
+	do {
+		if(ioctl(dev, DIOCGETRULE, &pr) < 0)
+		{
+			syslog(LOG_ERR, "ioctl(dev, DIOCGETRULE): %m");
+			goto error;
+		}
+	} while ( pr.nr != (unsigned int)index );
 #endif /* USE_LIBPFCTL */
 	*proto = RULE.proto;
 #ifdef __APPLE__


### PR DESCRIPTION
- miniupnpd/pf/obsdrdr.c
  Fixes rules not being removed from the pf anchor when they expire
    Apparently, it changed at some point and calling DIOCGETRULE
    always starts from the beginning of the list on OpenBSD 7.5
    (and possibly earlier - not entirely sure when this changed)
    This was the only place I found that needed this change, all
    other calls to DIOCGETRULE are already being run in a loop
    and work as intended

- miniupnpd ssdp changes
  Fixes a couple of issues with miniupnpd being the SSDP listener/server
  - miniupnpd/minissdp.c
      Fixes a runtime warning
  - miniupnpd/bsd/getroute.c
      Fixes routes not being found. Note that this changes it
      to be the same as the equivalent code in minissdp itself