### PR TITLE
miniupnpd: bind ssdp notify and pcp with v6 to device

### DIFF
--- a/miniupnpd/minissdp.c
+++ b/miniupnpd/minissdp.c
@@ -409,7 +409,7 @@ OpenAndConfSSDPNotifySocketIPv6(struct lan_addr_s * lan_addr)
 	{
 		if(setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE,
 		              lan_addrs.lh_first->ifname,
-		              strlen(lan_addrs.lh_first->ifname)) < 0)
+		              strlen(lan_addrs.lh_first->ifname) + 1) < 0)
 			syslog(LOG_WARNING, "%s: setsockopt(udp6, SO_BINDTODEVICE, %s): %m",
 			       "OpenAndConfSSDPNotifySocketIPv6",
 			       lan_addrs.lh_first->ifname);

--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -1652,6 +1652,20 @@ int OpenAndConfPCPv6Socket(void)
 		       "OpenAndConfPCPv6Socket");
 	}
 #endif
+#if defined(SO_BINDTODEVICE) && !defined(MULTIPLE_EXTERNAL_IP)
+	/* One and only one LAN interface and no bind any ipv6 addr */
+	if(lan_addrs.lh_first != NULL && lan_addrs.lh_first->list.le_next == NULL
+	   && lan_addrs.lh_first->ifname[0] != '\0' &&
+	   memcmp(&ipv6_bind_addr, &in6addr_any, sizeof(in6addr_any)) == 0 )
+	{
+		if(setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE,
+		              lan_addrs.lh_first->ifname,
+		              strlen(lan_addrs.lh_first->ifname)) < 0)
+			syslog(LOG_WARNING, "%s: setsockopt(udp6, SO_BINDTODEVICE, %s): %m",
+			       "OpenAndConfPCPv6Socket",
+			       lan_addrs.lh_first->ifname);
+	}
+#endif /* defined(SO_BINDTODEVICE) && !defined(MULTIPLE_EXTERNAL_IP) */
 #ifdef IPV6_RECVPKTINFO
 	/* see RFC3542 */
 	if(setsockopt(s, IPPROTO_IPV6, IPV6_RECVPKTINFO, &i, sizeof(i)) < 0) {

--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -1660,7 +1660,7 @@ int OpenAndConfPCPv6Socket(void)
 	{
 		if(setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE,
 		              lan_addrs.lh_first->ifname,
-		              strlen(lan_addrs.lh_first->ifname)) < 0)
+		              strlen(lan_addrs.lh_first->ifname) + 1) < 0)
 			syslog(LOG_WARNING, "%s: setsockopt(udp6, SO_BINDTODEVICE, %s): %m",
 			       "OpenAndConfPCPv6Socket",
 			       lan_addrs.lh_first->ifname);


### PR DESCRIPTION
Bind ipv6 socket to the interface to completely solve the threat of directional attacks caused by WAN port scanners and leaked IPs