### PR TITLE
miniupnpc: fix sendto buffer overrun

### DIFF
--- a/miniupnpc/src/minissdpc.c
+++ b/miniupnpc/src/minissdpc.c
@@ -913,7 +913,7 @@ ssdpDiscoverDevices(const char * const deviceTypes[],
 					}
 #endif
 					PRINT_SOCKET_ERROR("sendto");
-					continue;
+					break;
 				} else {
 					sentok = 1;
 				}


### PR DESCRIPTION
Old issue that was already present in miniupnpc.c when the project transitioned to git in c183a72c46cae9e37ddf635318dfb0bdcd56ed9d. (and later that incorrect piece of code moved from miniupnpc.c to minissdpc.c in 353f1016551e23c84885ccb0f21a19b46021168a).

When we reach `PRINT_SOCKET_ERROR("sendto");`, then the value of `n` is -1 (aka 18446744073709551615), which is always larger than the buffer size. So `continue` would cause a buffer overrun. The proper action is to `break`.