### PR TITLE
miniupnpd: Add ignore_private_ip option

### DIFF
--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -18,6 +18,11 @@
 # the public IP address.
 #ext_ip=
 
+# Force ignore private IP check for UPNP, useful for some cases such as
+# full-cone NAT detection mechanism is not working properly.
+# This option is disabled by default.
+#ignore_private_ip=yes
+
 # The WAN interface must have a public IP address. Otherwise it is behind NAT
 # and port forwarding is impossible. In some cases WAN interface can be
 # behind unrestricted full-cone NAT 1:1 when all incoming traffic is NAT-ed and

--- a/miniupnpd/natpmp.c
+++ b/miniupnpd/natpmp.c
@@ -109,7 +109,7 @@ static void FillPublicAddressResponse(unsigned char * resp, in_addr_t senderaddr
 			syslog(LOG_ERR, "Failed to get IP for interface %s", ext_if_name);
 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
 			                 * has not obtained a DHCP lease) */
-		} else if (addr_is_reserved(&addr)) {
+		} else if (addr_is_reserved(&addr) && !GETFLAG(IGNOREPRIVATEIPMASK)) {
 			resp[3] = 3;	/* Network Failure, box has not obtained
 			                   public IP address */
 		} else {

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -35,6 +35,7 @@ static const struct {
 	{ UPNPEXT_IFNAME6, "ext_ifname6" },
 #endif
 	{ UPNPEXT_IP,	"ext_ip" },
+	{ UPNP_IGNORE_PRIVATE_IP, "ignore_private_ip" },
 	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
 	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
 	{ UPNPEXT_STUN_PORT, "ext_stun_port" },

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -21,6 +21,7 @@ enum upnpconfigoptions {
 	UPNPEXT_IFNAME6,		/* ext_ifname6 */
 #endif
 	UPNPEXT_IP,				/* ext_ip */
+	UPNP_IGNORE_PRIVATE_IP, /* ignore_private_ip */
 	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
 	UPNPEXT_STUN_HOST,		/* ext_stun_host */
 	UPNPEXT_STUN_PORT,		/* ext_stun_port */

--- a/miniupnpd/testgetifaddr.c
+++ b/miniupnpd/testgetifaddr.c
@@ -18,6 +18,8 @@
 #define LOG_PERROR 0
 #endif
 
+int runtime_flags = 0;
+
 int main(int argc, char * * argv) {
 	char str_addr[64];
 	struct in_addr addr;

--- a/miniupnpd/testportinuse.c
+++ b/miniupnpd/testportinuse.c
@@ -14,6 +14,8 @@
 #include "config.h"
 #include "portinuse.h"
 
+int runtime_flags = 0;
+
 int main(int argc, char * * argv)
 {
 #ifndef CHECK_PORTINUSE

--- a/miniupnpd/upnpdescgen.c
+++ b/miniupnpd/upnpdescgen.c
@@ -1316,7 +1316,7 @@ genEventVars(int * len, const struct serviceDesc * s)
 				else {
 					struct in_addr addr;
 					char ext_ip_addr[INET_ADDRSTRLEN];
-					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || addr_is_reserved(&addr)) {
+					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || (addr_is_reserved(&addr) && !GETFLAG(IGNOREPRIVATEIPMASK))) {
 						str = strcat_str(str, len, &tmplen, "0.0.0.0");
 					} else {
 						str = strcat_str(str, len, &tmplen, ext_ip_addr);

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -87,6 +87,8 @@ extern int runtime_flags;
 
 #define PERFORMSTUNMASK    0x1000
 
+#define IGNOREPRIVATEIPMASK 0x2000
+
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)
 #define CLEARFLAG(mask)	runtime_flags &= ~mask

--- a/miniupnpd/upnpredirect.c
+++ b/miniupnpd/upnpredirect.c
@@ -445,7 +445,7 @@ upnp_redirect_internal(const char * rhost, unsigned short eport,
 {
 	/*syslog(LOG_INFO, "redirecting port %hu to %s:%hu protocol %s for: %s",
 		eport, iaddr, iport, protocol, desc);			*/
-	if(disable_port_forwarding)
+	if(disable_port_forwarding && !GETFLAG(IGNOREPRIVATEIPMASK))
 		return -1;
 	if(add_redirect_rule2(ext_if_name, rhost, eport, iaddr, iport, proto,
 	                      desc, timestamp) < 0) {

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -371,7 +371,11 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
 			ext_ip_addr[0] = '\0';
 		} else if (addr_is_reserved(&addr)) {
 			syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);
-			ext_ip_addr[0] = '\0';
+			if (!GETFLAG(IGNOREPRIVATEIPMASK)) {
+				ext_ip_addr[0] = '\0';
+			} else {
+				syslog(LOG_NOTICE, "ignore_private_ip is enabled, private/reserved address %s is used as external IP", ext_ip_addr);
+			}
 		}
 	}
 #else


### PR DESCRIPTION
In case that router getting private IP but upstream server has full-cone NAT enabled, current full-cone NAT detect mechanism would make miniupnpd stop working. So add force_forwarding option to let user optionally force bypassing this mechanism.

This PR should close https://github.com/miniupnp/miniupnp/issues/785 https://github.com/miniupnp/miniupnp/issues/705