### PR TITLE
miniunpnpd: Unify naming scheme and rename to ext_ignore_private_ip_check for ignore_private_ip_check

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -1,5 +1,11 @@
 $Id: Changelog.txt,v 1.529 2025/04/08 21:28:41 nanard Exp $
 
+2025/04/10:
+  Unify naming scheme and rename to ext_allow_private_ipv4 for
+  ignore_private_ip_check
+  Remove the ability to disable port forwarding for
+  update_ext_ip_addr_from_stun function
+
 2025/04/08:
   improve get_wan_connection_status()
 

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1041,7 +1041,7 @@ parselanaddr(struct lan_addr_s * lan_addr, const char * str, int debug_flag)
 				return -1;
 			}
 			if(addr_is_reserved(&lan_addr->ext_ip_addr)) {
-				if (GETFLAG(IGNOREPRIVATEIPMASK)) {
+				if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
 					syslog(LOG_WARNING, "IGNORED : option ext_ip address contains reserved / private address : %s", lan_addr->ext_ip_str);
 				} else {
 					/* error */
@@ -1176,7 +1176,7 @@ static void update_disable_port_forwarding(void)
 	} else {
 		int reserved = addr_is_reserved(&addr);
 		if (!disable_port_forwarding && reserved) {
-			if (GETFLAG(IGNOREPRIVATEIPMASK)) {
+			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
 				syslog(LOG_WARNING, "IGNORED : Reserved / private IP address %s on ext interface %s", if_addr, ext_if_name);
 			} else {
 				syslog(LOG_WARNING, "Reserved / private IP address %s on ext interface %s: Port forwarding is impossible", if_addr, ext_if_name);
@@ -1337,9 +1337,9 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPEXT_IP:
 				use_ext_ip_addr = ary_options[i].value;
 				break;
-			case UPNP_IGNORE_PRIVATE_IP:
+			case UPNPEXT_ALLOW_PRIVATE_IPV4:
 				if(strcmp(ary_options[i].value, "yes") == 0)
-					SETFLAG(IGNOREPRIVATEIPMASK);
+					SETFLAG(ALLOWPRIVATEIPV4MASK);
 				break;
 			case UPNPEXT_PERFORM_STUN:
 				if(strcmp(ary_options[i].value, "yes") == 0)
@@ -1953,7 +1953,7 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			return 1;
 		}
 		if (addr_is_reserved(&addr)) {
-			if (GETFLAG(IGNOREPRIVATEIPMASK)) {
+			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
 				syslog(LOG_WARNING, "IGNORED : option ext_ip contains reserved / private address %s, not public routable", use_ext_ip_addr);
 			} else {
 				INIT_PRINT_ERR("Error: option ext_ip contains reserved / private address %s, not public routable\n", use_ext_ip_addr);

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1134,20 +1134,18 @@ int update_ext_ip_addr_from_stun(int init)
 		syslog(LOG_INFO, "Port forwarding is now enabled");
 	} else if ((init || !disable_port_forwarding) && restrictive_nat) {
 		if (addr_is_reserved(&if_addr)) {
-			syslog(LOG_WARNING, "STUN: ext interface %s with private IP address %s is now behind restrictive or symmetric NAT with public IP address %s which does not support port forwarding", ext_if_name, if_addr_str, ext_addr_str);
+			syslog(LOG_WARNING, "STUN: ext interface %s with private IP address %s is now possibly behind restrictive or symmetric NAT with public IP address %s which does not support port forwarding", ext_if_name, if_addr_str, ext_addr_str);
 			syslog(LOG_WARNING, "NAT on upstream router blocks incoming connections set by miniupnpd");
 			syslog(LOG_WARNING, "Turn off NAT on upstream router or change it to full-cone NAT 1:1 type");
 		} else {
 			syslog(LOG_WARNING, "STUN: ext interface %s has now public IP address %s but firewall filters incoming connections set by miniunnpd", ext_if_name, if_addr_str);
 			syslog(LOG_WARNING, "Check configuration of firewall on local machine and also on upstream router");
 		}
-		syslog(LOG_WARNING, "Port forwarding is now disabled");
 	} else {
 		syslog(LOG_INFO, "STUN: ... done");
 	}
 
 	use_ext_ip_addr = ext_addr_str;
-	disable_port_forwarding = restrictive_nat;
 	return 0;
 }
 

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -18,10 +18,12 @@
 # the public IP address.
 #ext_ip=
 
-# Ignore private IP check for UPNP, useful for some cases such as
-# full-cone NAT detection mechanism is not working properly.
+# Allow private IP address on external interfaces, useful for some cases such as
+# full-cone NAT (which is renamed as endpoint-independent NAT in newer RFC
+# documents, for example, RFC5780 section 3.2) detection mechanism is not
+# working properly.
 # This option is disabled by default.
-#ignore_private_ip_check=yes
+#ext_allow_private_ipv4=yes
 
 # The WAN interface must have a public IP address. Otherwise it is behind NAT
 # and port forwarding is impossible. In some cases WAN interface can be

--- a/miniupnpd/natpmp.c
+++ b/miniupnpd/natpmp.c
@@ -109,7 +109,7 @@ static void FillPublicAddressResponse(unsigned char * resp, in_addr_t senderaddr
 			syslog(LOG_ERR, "Failed to get IP for interface %s", ext_if_name);
 			resp[3] = 3;	/* Network Failure (e.g. NAT box itself
 			                 * has not obtained a DHCP lease) */
-		} else if (!GETFLAG(IGNOREPRIVATEIPMASK) && addr_is_reserved(&addr)) {
+		} else if (!GETFLAG(ALLOWPRIVATEIPV4MASK) && addr_is_reserved(&addr)) {
 			resp[3] = 3;	/* Network Failure, box has not obtained
 			                   public IP address */
 		} else {

--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -35,7 +35,7 @@ static const struct {
 	{ UPNPEXT_IFNAME6, "ext_ifname6" },
 #endif
 	{ UPNPEXT_IP,	"ext_ip" },
-	{ UPNP_IGNORE_PRIVATE_IP, "ignore_private_ip_check" },
+	{ UPNPEXT_ALLOW_PRIVATE_IPV4, "ext_allow_private_ipv4" },
 	{ UPNPEXT_PERFORM_STUN, "ext_perform_stun" },
 	{ UPNPEXT_STUN_HOST, "ext_stun_host" },
 	{ UPNPEXT_STUN_PORT, "ext_stun_port" },

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -21,7 +21,7 @@ enum upnpconfigoptions {
 	UPNPEXT_IFNAME6,		/* ext_ifname6 */
 #endif
 	UPNPEXT_IP,				/* ext_ip */
-	UPNP_IGNORE_PRIVATE_IP,	/* ignore_private_ip_check */
+	UPNPEXT_ALLOW_PRIVATE_IPV4,	/* ext_allow_private_ipv4 */
 	UPNPEXT_PERFORM_STUN,		/* ext_perform_stun */
 	UPNPEXT_STUN_HOST,		/* ext_stun_host */
 	UPNPEXT_STUN_PORT,		/* ext_stun_port */

--- a/miniupnpd/upnpdescgen.c
+++ b/miniupnpd/upnpdescgen.c
@@ -1316,7 +1316,7 @@ genEventVars(int * len, const struct serviceDesc * s)
 				else {
 					struct in_addr addr;
 					char ext_ip_addr[INET_ADDRSTRLEN];
-					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || (!GETFLAG(IGNOREPRIVATEIPMASK) && addr_is_reserved(&addr))) {
+					if(getifaddr(ext_if_name, ext_ip_addr, INET_ADDRSTRLEN, &addr, NULL) < 0 || (!GETFLAG(ALLOWPRIVATEIPV4MASK) && addr_is_reserved(&addr))) {
 						str = strcat_str(str, len, &tmplen, "0.0.0.0");
 					} else {
 						str = strcat_str(str, len, &tmplen, ext_ip_addr);

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -87,7 +87,7 @@ extern int runtime_flags;
 
 #define PERFORMSTUNMASK    0x1000
 
-#define IGNOREPRIVATEIPMASK 0x2000
+#define ALLOWPRIVATEIPV4MASK 0x2000
 
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)

--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -370,7 +370,7 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
 				ext_if_name);
 			ext_ip_addr[0] = '\0';
 		} else if (addr_is_reserved(&addr)) {
-			if (!GETFLAG(IGNOREPRIVATEIPMASK)) {
+			if (!GETFLAG(ALLOWPRIVATEIPV4MASK)) {
 				syslog(LOG_WARNING, "IGNORED : private/reserved address %s is not suitable for external IP", ext_ip_addr);
 			} else {
 				syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);


### PR DESCRIPTION
Currently we are using a mix of "ignore private ip" and "ignore private ip check" in code. Let's unify them to "ext ignore private ip check". We always use private ip in most cases for internal interfaces, and it would be confusing if we don't use ext prefix.

Besides, full-cone NAT, which is also named as endpoint-independent NAT in some IETF RFC document. Add this name and a source of it to miniupnpd.conf.