### PR TITLE
miniupnpd: Add ext_perform_stun=allow-filtered option

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -1,5 +1,10 @@
 $Id: Changelog.txt,v 1.529 2025/04/08 21:28:41 nanard Exp $
 
+2025/04/16:
+  Restore the default behavior of update_ext_ip_addr_from_stun function,
+    and now setting ext_perform_stun=allow-filtered would allow failed
+    STUN CGNAT filter check to be ignored
+
 2025/04/10:
   Unify naming scheme and rename to ext_allow_private_ipv4 for
   ignore_private_ip_check

--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1141,11 +1141,17 @@ int update_ext_ip_addr_from_stun(int init)
 			syslog(LOG_WARNING, "STUN: ext interface %s has now public IP address %s but firewall filters incoming connections set by miniunnpd", ext_if_name, if_addr_str);
 			syslog(LOG_WARNING, "Check configuration of firewall on local machine and also on upstream router");
 		}
+		if (!GETFLAG(ALLOWFILTEREDSTUNMASK)) {
+			syslog(LOG_WARNING, "Port forwarding is now disabled");
+			syslog(LOG_WARNING, "Set ext_perform_stun=allow-filtered if you still want to use port forwarding in current situation");
+		}
 	} else {
 		syslog(LOG_INFO, "STUN: ... done");
 	}
 
 	use_ext_ip_addr = ext_addr_str;
+	if (!GETFLAG(ALLOWFILTEREDSTUNMASK))
+		disable_port_forwarding = restrictive_nat;
 	return 0;
 }
 
@@ -1342,6 +1348,11 @@ init(int argc, char * * argv, struct runtime_vars * v)
 			case UPNPEXT_PERFORM_STUN:
 				if(strcmp(ary_options[i].value, "yes") == 0)
 					SETFLAG(PERFORMSTUNMASK);
+				if(strcmp(ary_options[i].value, "allow-filtered") == 0)
+				{
+					SETFLAG(PERFORMSTUNMASK);
+					SETFLAG(ALLOWFILTEREDSTUNMASK);
+				}
 				break;
 			case UPNPEXT_STUN_HOST:
 				ext_stun_host = ary_options[i].value;

--- a/miniupnpd/miniupnpd.conf
+++ b/miniupnpd/miniupnpd.conf
@@ -18,10 +18,8 @@
 # the public IP address.
 #ext_ip=
 
-# Allow private IP address on external interfaces, useful for some cases such as
-# full-cone NAT (which is renamed as endpoint-independent NAT in newer RFC
-# documents, for example, RFC5780 section 3.2) detection mechanism is not
-# working properly.
+# Allow private IP address on external interface. When set to yes, program
+# won't just disable port forwarding when external address is private IP.
 # This option is disabled by default.
 #ext_allow_private_ipv4=yes
 
@@ -33,6 +31,8 @@
 # server via STUN protocol. Following option enable retrieving external
 # public IP address from STUN server and detection of NAT type. You need
 # to specify also external STUN server in stun_host option below.
+# STUN CGNAT filter check result would be ignored when deciding whether to
+# disable port forwarding if setting this option to allow-filtered.
 # This option is disabled by default.
 #ext_perform_stun=yes
 

--- a/miniupnpd/upnpglobalvars.h
+++ b/miniupnpd/upnpglobalvars.h
@@ -88,6 +88,7 @@ extern int runtime_flags;
 #define PERFORMSTUNMASK    0x1000
 
 #define ALLOWPRIVATEIPV4MASK 0x2000
+#define ALLOWFILTEREDSTUNMASK 0x4000
 
 #define SETFLAG(mask)	runtime_flags |= mask
 #define GETFLAG(mask)	(runtime_flags & mask)


### PR DESCRIPTION
This commit partitally reverts back the default behavior which has been altered by 276db87ca093 ("miniunpnpd: Remove the ability to disable port forwarding for update_ext_ip_addr_from_stun function").

Allow failed STUN CGNAT filter check to be ignored by by setting ext_perform_stun=allow-filtered.

@miniupnp Sorry for bothering you again, but in previous PR we have changed default behavior of miniupnpd. This might break some users' configuration. So I have added back the default behavior and allowed ext_perform_stun to be set to allow-filtered in this PR.