### PR TITLE
NFTables: don't apply iif to rules if USE_IFNAME_IN_RULES is disabled

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -1,5 +1,8 @@
 $Id: Changelog.txt,v 1.529 2025/04/08 21:28:41 nanard Exp $
 
+2025/04/25:
+  NFTables: don't apply iif to rules if USE_IFNAME_IN_RULES is disabled
+
 2025/04/10:
   Unify naming scheme and rename to ext_allow_private_ipv4 for
   ignore_private_ip_check

--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -1010,7 +1010,7 @@ echo " * It can be disabled to save a few bytes. */" >> ${CONFIGFILE}
 echo "#define ENABLE_EVENTS" >> ${CONFIGFILE}
 echo "" >> ${CONFIGFILE}
 
-echo "/* include interface name in pf and ipf rules */" >> ${CONFIGFILE}
+echo "/* include interface name in pf, ipf and nftables rules */" >> ${CONFIGFILE}
 echo "#define USE_IFNAME_IN_RULES" >> ${CONFIGFILE}
 echo "" >> ${CONFIGFILE}
 

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -987,12 +987,14 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 		nftnl_rule_set_u64(r, NFTNL_RULE_POSITION, handle_num);
 	}
 
+#ifdef USE_IFNAME_IN_RULES
 	if (ifname != NULL) {
 		if_idx = (uint32_t)if_nametoindex(ifname);
 		expr_add_meta(r, NFT_META_IIF, NFT_REG_1);
 		expr_add_cmp(r, NFT_REG_1, NFT_CMP_EQ, &if_idx,
 			     sizeof(uint32_t));
 	}
+#endif
 
 	/* Source IP */
 	if (rhost != 0) {
@@ -1143,12 +1145,14 @@ rule_set_filter_common(struct nftnl_rule *r, uint8_t family, const char * ifname
 		nftnl_rule_set_u64(r, NFTNL_RULE_POSITION, handle_num);
 	}
 
+#ifdef USE_IFNAME_IN_RULES
 	if (ifname != NULL) {
 		if_idx = (uint32_t)if_nametoindex(ifname);
 		expr_add_meta(r, NFT_META_IIF, NFT_REG_1);
 		expr_add_cmp(r, NFT_REG_1, NFT_CMP_EQ, &if_idx,
 			     sizeof(uint32_t));
 	}
+#endif
 
 	/* Destination Port */
 	dport = htons(iport);


### PR DESCRIPTION
This small patch skips setting the iif / ifname when using nftables if USE_IFNAME_IN_RULES is not defined. This feature exists for pf and ipf and so I've extended it for my use case with nftables.