### PR TITLE
NFTables: add counter to DNAT rules enabling clean_ruleset_interval

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -10,6 +10,9 @@ VERSION 2.3.9 : released on 2025/04/22
     and now setting ext_perform_stun=allow-filtered would allow failed
     STUN CGNAT filter check to be ignored
 
+2025/04/25:
+  NFTables: don't apply iif to rules if USE_IFNAME_IN_RULES is disabled
+
 2025/04/10:
   Unify naming scheme and rename to ext_allow_private_ipv4 for
   ignore_private_ip_check

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -608,8 +608,6 @@ get_nat_redirect_rule(const char * nat_chain_name, const char * ifname,
 	struct in_addr addr;
 	UNUSED(nat_chain_name);
 	UNUSED(ifname);
-	UNUSED(packets);
-	UNUSED(bytes);
 	UNUSED(rhost);
 	UNUSED(rhostlen);
 
@@ -636,6 +634,11 @@ get_nat_redirect_rule(const char * nat_chain_name, const char * ifname,
 
 			if(timestamp != NULL)
 				*timestamp = get_timestamp(eport, proto);
+
+			if(packets)
+				*packets = p->packets;
+			if(bytes)
+				*bytes = p->bytes;
 
 			return 0;
 		}

--- a/miniupnpd/netfilter_nft/nftnlrdr.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr.c
@@ -465,9 +465,7 @@ get_peer_rule_by_index(int index,
 			if (timestamp) {
 				*timestamp = get_timestamp(r->dport, r->proto);
 			}
-			/*
-			 * TODO: Implement counter in case of add {nat,filter}
-			 */
+
 			return 0;
 		}
 	}
@@ -581,9 +579,6 @@ get_redirect_rule_by_index(int index,
 					*bytes = r->bytes;
 			}
 
-			/*
-			 * TODO: Implement counter in case of add {nat,filter}
-			 */
 			return 0;
 		}
 	}

--- a/miniupnpd/netfilter_nft/nftnlrdr_misc.c
+++ b/miniupnpd/netfilter_nft/nftnlrdr_misc.c
@@ -795,6 +795,20 @@ expr_add_cmp(struct nftnl_rule *r, uint32_t sreg, uint32_t op,
 }
 
 static void
+expr_add_counter(struct nftnl_rule *r)
+{
+	struct nftnl_expr *e;
+
+	e = nftnl_expr_alloc("counter");
+	if (e == NULL) {
+		log_error("nftnl_expr_alloc(\"%s\") FAILED", "counter");
+		return;
+	}
+
+	nftnl_rule_add_expr(r, e);
+}
+
+static void
 expr_add_meta(struct nftnl_rule *r, uint32_t meta_key, uint32_t dreg)
 {
 	struct nftnl_expr *e;
@@ -1021,6 +1035,9 @@ rule_set_dnat(uint8_t family, const char * ifname, uint8_t proto,
 		                 offsetof(struct udphdr, dest), sizeof(uint16_t));
 		expr_add_cmp(r, NFT_REG_1, NFT_CMP_EQ, &dport, sizeof(uint16_t));
 	}
+
+	/* Counter */
+	expr_add_counter(r);
 
 	expr_add_nat(r, NFT_NAT_DNAT, NFPROTO_IPV4, ihost, htons(iport), 0);
 


### PR DESCRIPTION
Another small patch to add counters to nftable rules for DNAT. This allows `clean_ruleset_interval` to detect rules with no traffic and remove them.