### PR TITLE
miniupnpd/pf: fix delete_pinhole for openbsd

### DIFF
--- a/miniupnpd/pf/pfpinhole.c
+++ b/miniupnpd/pf/pfpinhole.c
@@ -349,6 +349,8 @@ int delete_pinhole(unsigned short uid)
 			pr.ticket = ri.ticket;
 			pr.nr = i;
 			strlcpy(pr.anchor, anchor_name, MAXPATHLEN);
+#else /* USE_LIBPFCTL */
+			pr.action = PF_CHANGE_GET_TICKET;
 #endif /* USE_LIBPFCTL */
 			if(ioctl(dev, DIOCCHANGERULE, &pr) < 0) {
 				syslog(LOG_ERR, "ioctl(dev, DIOCCHANGERULE, ...) PF_CHANGE_GET_TICKET: %m");


### PR DESCRIPTION
commit 2be63c9 (pfpinhole.c: use libpfctl, 2024-06-08) added compile time conditions to support libpfctl, but it also mistakenly guarded setting the pfioc_rule action to PF_CHANGE_GET_TICKET.

set the pfioc_rule action once again to PF_CHANGE_GET_TICKET in the non-libpfctl case for OpenBSD. this fixes 'upnpc -D'. without this, we'd get EINVAL from the DIOCCHANGERULE ioctl.