### PR TITLE
miniupnpd: Fix false negative filtered STUN CGNAT test result

### DIFF
--- a/miniupnpd/Changelog.txt
+++ b/miniupnpd/Changelog.txt
@@ -1,5 +1,9 @@
 $Id: Changelog.txt,v 1.535 2025/04/26 13:07:53 nanard Exp $
 
+2025/05/05:
+  Fix false negative filtered STUN CGNAT test result for
+    unsupported servers #825
+
 2025/04/28:
   pf: fix delete_pinhole for openbsd. Was broken since miniupnpd 2.3.7
 


### PR DESCRIPTION
This commit has multiple changes:

Fix CGNAT test result for unsupported STUN servers not returning OTHER-ADDRESS / supporting CHANGE-REQUEST's required for endpoint- independent (1:1) CGNAT filtering tests. Since an unsupported server will simply ignore the CHANGE-REQUEST attribute and respond from the same IP/port, it reaches the daemon causing the false negative filtered result before.

For unsupported servers, display an error indicating compatible ones, and then fail.

Simplify STUN CGNAT tests with two different STUN requests. Now, the first (of four) tests server connectivity, while all subsequent (change-IP / change-port set) for an unrestricted endpoint-independent (1:1) CGNAT per RFC 5780 4.4 test I/II, see[1].

Log unknown STUN attributes as debug instead of warning.

STUN IPv4 CGNAT detection briefly described as code comment and existing ones updated.

An important point to note is that the `miniupnpd.conf` example should only suggest STUN servers that are compatible. This is addressed in PR #798, among others.

[1]: https://datatracker.ietf.org/doc/html/rfc5780#section-4.4