### PR TITLE
miniupnpd: fix testportinuse build on bsd with the --portinuse configure option

### DIFF
--- a/miniupnpd/Makefile.bsd
+++ b/miniupnpd/Makefile.bsd
@@ -99,7 +99,8 @@ TESTUPNPPERMISSIONSOBJS = testupnppermissions.o upnppermissions.o
 TESTGETIFADDROBJS = testgetifaddr.o getifaddr.o getconnstatus.o
 MINIUPNPDCTLOBJS = miniupnpdctl.o
 TESTASYNCSENDTOOBJS = testasyncsendto.o asyncsendto.o upnputils.o getroute.o
-TESTPORTINUSEOBJS = testportinuse.o portinuse.o getifaddr.o
+TESTPORTINUSEOBJS = testportinuse.o portinuse.o getifaddr.o upnputils.o \
+                    getroute.o
 TESTMINISSDPOBJS = testminissdp.o minissdp.o upnputils.o upnpglobalvars.o \
                    asyncsendto.o getroute.o
 TESTIFACEWATCHEROBJS = testifacewatcher.o ifacewatcher.o upnputils.o \

--- a/miniupnpd/Makefile.macosx
+++ b/miniupnpd/Makefile.macosx
@@ -51,7 +51,8 @@ TEST_UPNPDESCGEN_OBJS = testupnpdescgen.o upnpdescgen.o
 TEST_GETIFSTATS_OBJS = testgetifstats.o mac/getifstats.o
 TEST_UPNPPERMISSIONS_OBJS = testupnppermissions.o upnppermissions.o
 TEST_GETIFADDR_OBJS = testgetifaddr.o getifaddr.o
-TEST_PORTINUSE_OBJS = testportinuse.o portinuse.o getifaddr.o
+TEST_PORTINUSE_OBJS = testportinuse.o portinuse.o getifaddr.o upnputils.o \
+                      bsd/getroute.o
 TEST_ASYNCSENDTO_OBJS = testasyncsendto.o asyncsendto.o upnputils.o bsd/getroute.o
 MINIUPNPDCTL_OBJS = miniupnpdctl.o
 

--- a/miniupnpd/Makefile.sunos
+++ b/miniupnpd/Makefile.sunos
@@ -78,7 +78,8 @@ TESTUPNPPERMISSIONSOBJS = testupnppermissions.o upnppermissions.o
 TESTGETIFADDROBJS = testgetifaddr.o getifaddr.o
 MINIUPNPDCTLOBJS = miniupnpdctl.o
 TESTASYNCSENDTOOBJS = testasyncsendto.o asyncsendto.o upnputils.o bsd/getroute.o
-TESTPORTINUSEOBJS = testportinuse.o portinuse.o getifaddr.o
+TESTPORTINUSEOBJS = testportinuse.o portinuse.o getifaddr.o upnputils.o \
+                    bsd/getroute.o
 
 EXECUTABLES = miniupnpd testupnpdescgen testgetifstats \
               testupnppermissions miniupnpdctl \

--- a/miniupnpd/testportinuse.c
+++ b/miniupnpd/testportinuse.c
@@ -16,6 +16,7 @@
 #include "upnpglobalvars.h"
 
 struct lan_addr_list lan_addrs;
+int runtime_flags = 0;
 time_t startup_time = 0;
 
 int main(int argc, char * * argv)


### PR DESCRIPTION
testportinuse build fails because proto_itoa() is moved to upnputils.c but the make rule is not updated in Makefile.bsd.
Also update Makefile.macosx and Makefile.sunos since it looks that they require the same fix.