### PR TITLE
fix: An undefined value may be read from 'errno'

### DIFF
--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -140,8 +140,8 @@ SOCKET connecthostport(const char * host, unsigned short port,
 			closesocket(s);
 			return INVALID_SOCKET;
 		}
+		errno = err;
 		if(err != 0) {
-			errno = err;
 			n = -1;
 		}
 	}
@@ -258,8 +258,8 @@ SOCKET connecthostport(const char * host, unsigned short port,
 				freeaddrinfo(ai);
 				return INVALID_SOCKET;
 			}
+			errno = err;
 			if(err != 0) {
-				errno = err;
 				n = -1;
 			}
 		}


### PR DESCRIPTION
This is from Xcode analyzer:
![Capture d’écran 2025-05-20 à 08 23 26](https://github.com/user-attachments/assets/ac8b108c-984b-4873-a1b4-0cc45e1a0097)

In essence:
- Assuming MINIUPNPC_IGNORE_EINTR is defined (and we hit a EINTR or EINPROGRESS)
- Assuming `n == -1` after `select`, but `errno != EINTR` so we don't `continue` on line 244.
- Then the `getsockopt` on line 255 makes 'errno' become undefined after the call.
- If err was 0, we're looping back and comparing an undefined value to EINTR/EINPROGRESS.

Possible solutions:

A. if `err` is 0, then set `errno` to 0 too, which will quit the `while` loop, and move to the next addrinfo. [**this is what this PR is doing**]

B. if `err` is 0, then set `n = 0`, which will quit both the `while` loop and the `for` loop.

C. save the previous errno from `select` and re-apply it after `getsockopt`.

History: this issue might date back from the file first commit in 2011 (c183a72c46cae9e37ddf635318dfb0bdcd56ed9d).