### PR TITLE
fix: An undefined value may be read from 'errno'

### DIFF
--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -123,7 +123,7 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #else
 		n = select(s + 1, NULL, &wset, NULL, NULL);
 #endif
-		if(n == -1) {
+		if(n < 0) {
 			if (errno == EINTR)
 				continue;	/* try again */
 			else
@@ -242,7 +242,7 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #else
 			n = select(s + 1, NULL, &wset, NULL, NULL);
 #endif
-			if(n == -1) {
+			if(n < 0) {
 				if (errno == EINTR)
 					continue;	/* try again */
 				else


### PR DESCRIPTION
Follow up on #830.
The analyser is a bit confused that in one place we compare `while(n < 0)` and in the other we compare `if(n == -1)`. This results in the analyser believing there are situations where n would be less than -1.
![Capture d’écran 2025-05-21 à 09 36 29](https://github.com/user-attachments/assets/ddaf84c8-33a2-4c40-8b1d-4007a017c68f)

The solution to silence this false positive is to adopt the same comparison consistently: either `n < 0` in both places or `n == -1` in both places.

(or to set `errno = err` unconditionally but that has already been rejected in my previous PR)