### PR TITLE
Add WIN32_LEAN_AND_MEAN.

### DIFF
--- a/miniupnpc/src/addr_is_reserved.c
+++ b/miniupnpc/src/addr_is_reserved.c
@@ -8,6 +8,7 @@
  * provided LICENSE file. */
 #ifdef _WIN32
 /* Win32 Specific includes and defines */
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #if !defined(_MSC_VER)

--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdio.h>
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>

--- a/miniupnpc/src/minisoap.c
+++ b/miniupnpc/src/minisoap.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <io.h>
 #include <winsock2.h>
 #include "win32_snprintf.h"

--- a/miniupnpc/src/minissdpc.c
+++ b/miniupnpc/src/minissdpc.c
@@ -16,6 +16,7 @@
 #endif
 #if defined(_WIN32) || defined(__amigaos__) || defined(__amigaos4__)
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>

--- a/miniupnpc/src/miniupnpc.c
+++ b/miniupnpc/src/miniupnpc.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #ifdef _WIN32
 /* Win32 Specific includes and defines */
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>

--- a/miniupnpc/src/miniwget.c
+++ b/miniupnpc/src/miniwget.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <ctype.h>
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <io.h>

--- a/miniupnpc/src/receivedata.c
+++ b/miniupnpc/src/receivedata.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else /* _WIN32 */


### PR DESCRIPTION
As MS tells, this "can reduce the size of the Windows header files by excluding some of the less common API declarations".