### PR TITLE
miniupnpc: Empty paragraph passed to '\param' command

### DIFF
--- a/miniupnpc/include/miniupnpc.h
+++ b/miniupnpc/include/miniupnpc.h
@@ -281,7 +281,7 @@ GetUPNPUrls(struct UPNPUrls * urls, struct IGDdatas * data,
  * \brief free the members of a UPNPUrls struct
  *
  * All URLs buffers are freed and zeroed
- * \param[out] urls
+ * \param[out] urls URL structure to free
  */
 MINIUPNP_LIBSPEC void
 FreeUPNPUrls(struct UPNPUrls * urls);


### PR DESCRIPTION
Just a documentation warning fix.
![Capture d’écran 2025-05-25 à 16 05 50](https://github.com/user-attachments/assets/aa7df9b0-795c-4939-8202-6e8844c9cafd)
