### PR TITLE
upnpcommands.h: include <cstddef> for size_t

### DIFF
--- a/miniupnpc/include/upnpcommands.h
+++ b/miniupnpc/include/upnpcommands.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include <cstddef>
 #include "miniupnpc_declspec.h"
 #include "miniupnpctypes.h"
 


### PR DESCRIPTION
https://github.com/miniupnp/miniupnp/commit/83ac78c55af6d27c6e19a6e0de46da2d525d1a2d introduced `size_t` which appears to cause possible build issue for consumers, e.g. sunshine fails to build against miniupnpc 2.3.3 with

```
[...]
In file included from /var/tmp/paludis/build/net-remote-sunshine-2025.122.141614-r1/work/sunshine-2025.122.141614/src/upnp.cpp:7:
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:397:37: error: 'size_t' has not been declared
  397 |                                     size_t desclen,
      |                                     ^~~~~~
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:26:1: note: 'size_t' is defined in header '<cstddef>'; this is probably fixable by adding '#include <cstddef>'
   25 | #include "miniupnpctypes.h"
  +++ |+#include <cstddef>
   26 | 
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:469:36: error: 'size_t' has not been declared
  469 |                                    size_t desclen,
      |                                    ^~~~~~
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:469:36: note: 'size_t' is defined in header '<cstddef>'; this is probably fixable by adding '#include <cstddef>'
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:472:36: error: 'size_t' has not been declared
  472 |                                    size_t rHostlen,
      |                                    ^~~~~~
/usr/x86_64-pc-linux-gnu/include/miniupnpc/upnpcommands.h:472:36: note: 'size_t' is defined in header '<cstddef>'; this is probably fixable by adding '#include <cstddef>'
[...]
```