### PR TITLE
miniupnpd: `struct option` is incompatible with Darwin

### DIFF
--- a/miniupnpd/options.c
+++ b/miniupnpd/options.c
@@ -22,7 +22,7 @@
 #include "macros.h"
 
 #ifndef DISABLE_CONFIG_FILE
-struct option * ary_options = NULL;
+struct UPNPOption * ary_options = NULL;
 static char * string_repo = NULL;
 unsigned int num_options = 0;
 
@@ -263,7 +263,7 @@ readoptionsfile(const char * fname, int debug_flag)
 		}
 		else
 		{
-			tmp = realloc(ary_options, (num_options + 1) * sizeof(struct option));
+			tmp = realloc(ary_options, (num_options + 1) * sizeof(struct UPNPOption));
 			if(tmp == NULL)
 			{
 				INIT_PRINT_ERR("memory allocation error. Option in file %s line %d.\n",

--- a/miniupnpd/options.h
+++ b/miniupnpd/options.h
@@ -104,14 +104,14 @@ void
 freeoptions(void);
 
 /*! \brief option key / value structure */
-struct option
+struct UPNPOption
 {
 	enum upnpconfigoptions id;
 	const char * value;
 };
 
 /*! \brief option array */
-extern struct option * ary_options;
+extern struct UPNPOption * ary_options;
 /*! \brief length of option array */
 extern unsigned int num_options;
 


### PR DESCRIPTION
This is a build fix for building miniupnpd from Swift on macOS.
When attempting to build, we get those errors:

> Type 'struct option' has incompatible definitions in different translation units

>'option::name' from module 'Darwin.getopt' is not present in definition of 'struct option' provided earlier

This is happening because when building from Swift, we will somehow transiently include `<getopt.h>` (from either of `<sys/socket.h>` or `<syslog.h>` or some other system include).
And it already defines:
```
struct option {
	const char *name;
	int has_arg;
	int *flag;
	int val;
};
```

Since I can't prevent getopt.h from being included when building from Swift, I could only workaround the problem by renaming our `struct option` to something else.