### PR TITLE
minissdpd: Value stored to 's_ssdp' is never read

### DIFF
--- a/minissdpd/minissdpd.c
+++ b/minissdpd/minissdpd.c
@@ -1660,23 +1660,19 @@ int main(int argc, char * * argv)
 quit:
 	if(s_ssdp >= 0) {
 		close(s_ssdp);
-		s_ssdp = -1;
 	}
 #ifdef ENABLE_IPV6
 	if(s_ssdp6 >= 0) {
 		close(s_ssdp6);
-		s_ssdp6 = -1;
 	}
 #endif	/* ENABLE_IPV6 */
 	if(s_unix >= 0) {
 		close(s_unix);
-		s_unix = -1;
 		if(unlink(sockpath) < 0)
 			syslog(LOG_ERR, "unlink(%s): %m", sockpath);
 	}
 	if(s_ifacewatch >= 0) {
 		close(s_ifacewatch);
-		s_ifacewatch = -1;
 	}
 	/* empty LAN interface/address list */
 	while(lan_addrs.lh_first != NULL) {


### PR DESCRIPTION
Xcode analyser warning.
![Capture d’écran 2025-05-31 à 12 16 56](https://github.com/user-attachments/assets/fcee4098-64f8-4d03-abdc-41f27e299366)