### PR TITLE
miniupnpd: Value stored to 'j' is never read

### DIFF
--- a/miniupnpd/upnpdescgen.c
+++ b/miniupnpd/upnpdescgen.c
@@ -892,8 +892,9 @@ genXML(char * str, int * len, int * tmplen,
        int force_igd1)
 {
 #define GENXML_STACK_SIZE 16
-	unsigned short i, j;
-	int top;
+	unsigned short i = 0; /* current node */
+	unsigned short j; /* i + number of nodes */
+	int top = -1;
 	const char * eltname, *s;
 	char c;
 	struct {
@@ -905,9 +906,6 @@ genXML(char * str, int * len, int * tmplen,
 	UNUSED(force_igd1);
 #endif
 
-	top = -1;
-	i = 0;	/* current node */
-	j = 1;	/* i + number of nodes*/
 	for(;;)
 	{
 		eltname = p[i].eltname;


### PR DESCRIPTION
Warning from Xcode analyser.
![Capture d’écran 2025-05-31 à 12 49 37](https://github.com/user-attachments/assets/29a5ff30-2896-474c-8b14-669bf54c0971)
