### PR TITLE
miniupnpd: Value stored to 'remain' is never read

### DIFF
--- a/miniupnpd/pcpserver.c
+++ b/miniupnpd/pcpserver.c
@@ -530,7 +530,6 @@ static int parsePCPOption(uint8_t* pcp_buf, int remain, pcp_info_t *pcp_msg_info
 			syslog(LOG_ERR, "PCP: Unrecognized mandatory PCP OPTION: %d \n", (int)pcp_buf[0]);
 			/* Mandatory to understand */
 			pcp_msg_info->result_code = PCP_ERR_UNSUPP_OPTION;
-			remain = 0;
 			break;
 		}
 		/* TODO - log optional not understood options? */


### PR DESCRIPTION
Fix an Xcode analyser warning:
![Capture d’écran 2025-05-31 à 17 54 28](https://github.com/user-attachments/assets/5432bacd-95e2-4bb7-95a2-b3a39599c3f3)
