### PR TITLE
miniupnpd: fix ALLOWPRIVATEIPV4MASK condition

### DIFF
--- a/miniupnpd/upnpsoap.c
+++ b/miniupnpd/upnpsoap.c
@@ -370,7 +370,7 @@ GetExternalIPAddress(struct upnphttp * h, const char * action, const char * ns)
 				ext_if_name);
 			ext_ip_addr[0] = '\0';
 		} else if (addr_is_reserved(&addr)) {
-			if (!GETFLAG(ALLOWPRIVATEIPV4MASK)) {
+			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
 				syslog(LOG_WARNING, "IGNORED : private/reserved address %s is not suitable for external IP", ext_ip_addr);
 			} else {
 				syslog(LOG_NOTICE, "private/reserved address %s is not suitable for external IP", ext_ip_addr);


### PR DESCRIPTION
Fixed usage of private/reserved WAN addresses if they are allowed in the configuration.