### PR TITLE
miniupnpc: Use `poll()` where possible + Fix `FD_SET` crash bug

### DIFF
--- a/miniupnpc/src/receivedata.c
+++ b/miniupnpc/src/receivedata.c
@@ -63,6 +63,14 @@ receivedata(SOCKET socket,
 	/* using select under _WIN32 and amigaos */
     fd_set socketSet;
     TIMEVAL timeval;
+#ifndef _WIN32
+    /* Non-Windows, one needs to ensure the socket fd is within range */
+    if(socket >= FD_SETSIZE) {
+        fprintf(stderr, "Socket %d is >= FD_SETSIZE %d\n",
+                (int)socket, (int)FD_SETSIZE);
+        return -1;
+    }
+#endif
     FD_ZERO(&socketSet);
     FD_SET(socket, &socketSet);
     timeval.tv_sec = timeout / 1000;


### PR DESCRIPTION
Closes #857 .

This commit modifies the function `connecthostport` in `connecthostport.c` in order to prefer `poll` over `select`, on platforms that have it (such as POSIX systems). For platforms that lack it, the fallback is `select` (such as on Windows or AmigaOS).

The reason why `poll` is preferable here is that it does not suffer from the limitations of select (see: man 2 select, BUGS section), where if the file descriptor's value is `FD_SETSIZE` or greater, you cannot `select()` on it.

Additionally, this commit fixes #857, whereby the process could crash due to unchecked use of `FD_SET` when the fd is outside `FD_SETSIZE`. All usages of `FD_SET` for non-`poll` code paths are now checked (in miniupnpc at least).