### PR TITLE
miniupnpc: Replace deprecated dllwrap with gcc -shared for DLL build

### DIFF
--- a/miniupnpc/Makefile.mingw
+++ b/miniupnpc/Makefile.mingw
@@ -90,11 +90,10 @@ pythonmodule:	libminiupnpc.a
 	$(PYTHON) setupmingw32.py bdist_wheel --skip-build
 
 miniupnpc.dll:	miniupnpc.def $(OBJSDLL)
-	$(DLLWRAP) -k --driver-name $(CC) \
-	--def miniupnpc.def \
-	--output-def miniupnpc.dll.def \
-	--implib miniupnpc.lib -o $@ \
-	$(OBJSDLL) $(LDLIBS)
+	$(CC) -shared -o $@ $(OBJSDLL) $(LDLIBS) \
+	-Wl,--output-def,miniupnpc.dll.def \
+	-Wl,--out-implib,miniupnpc.lib \
+	miniupnpc.def
 
 miniupnpc.lib:	miniupnpc.dll
 


### PR DESCRIPTION
Closes: https://github.com/miniupnp/miniupnp/issues/860

This is just what worked for me on `windows-latest`. Feel free to make changes, or suggest them and I'll update my branch.