### PR TITLE
Fix Windows socket timeout handling in connecthostport.c

### DIFF
--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -71,7 +71,11 @@ SOCKET connecthostport(const char * host, unsigned short port,
 	struct addrinfo hints;
 #endif /* #ifdef USE_GETHOSTBYNAME */
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
+#ifdef _WIN32
+	DWORD timeout;
+#else
 	struct timeval timeout;
+#endif
 #endif /* #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT */
 
 #ifdef USE_GETHOSTBYNAME
@@ -91,15 +95,25 @@ SOCKET connecthostport(const char * host, unsigned short port,
 	}
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
 	/* setting a 3 seconds timeout for the connect() call */
+#ifdef _WIN32
+	timeout = 3000; /* milliseconds */
+	if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
+#else
 	timeout.tv_sec = 3;
 	timeout.tv_usec = 0;
 	if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(struct timeval)) < 0)
+#endif
 	{
 		PRINT_SOCKET_ERROR("setsockopt SO_RCVTIMEO");
 	}
+#ifdef _WIN32
+	timeout = 3000; /* milliseconds */
+	if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
+#else
 	timeout.tv_sec = 3;
 	timeout.tv_usec = 0;
 	if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(struct timeval)) < 0)
+#endif
 	{
 		PRINT_SOCKET_ERROR("setsockopt SO_SNDTIMEO");
 	}
@@ -212,15 +226,25 @@ SOCKET connecthostport(const char * host, unsigned short port,
 		}
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
 		/* setting a 3 seconds timeout for the connect() call */
+#ifdef _WIN32
+		timeout = 3000; /* milliseconds */
+		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
+#else
 		timeout.tv_sec = 3;
 		timeout.tv_usec = 0;
 		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(struct timeval)) < 0)
+#endif
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}
+#ifdef _WIN32
+		timeout = 3000; /* milliseconds */
+		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
+#else
 		timeout.tv_sec = 3;
 		timeout.tv_usec = 0;
 		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(struct timeval)) < 0)
+#endif
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}


### PR DESCRIPTION
## Summary

On Windows, `setsockopt()` for `SO_RCVTIMEO`/`SO_SNDTIMEO` expects:
- A `DWORD` containing the timeout in **milliseconds**
- A pointer cast to `(const char *)` for the option value

The previous code passed a `struct timeval` (8 bytes with `tv_sec=3`, `tv_usec=0`) but Windows would only read the first 4 bytes as a `DWORD`, interpreting the value `3` as **3 milliseconds** instead of the intended **3 seconds**.

## This was a latent bug

The bug appeared to work because:
1. Connections usually succeeded before the tiny 3ms timeout triggered
2. Older GCC versions only warned about the pointer type mismatch

GCC 14+ treats `-Wincompatible-pointer-types` as an error by default, exposing this issue during cross-compilation for Windows.

## Changes

- Use `DWORD` instead of `struct timeval` for timeout on Windows
- Set timeout to `3000` (milliseconds) instead of `tv_sec=3`
- Cast to `(const char *)` when calling `setsockopt()` on Windows

## Test plan

- [x] Linux native build passes
- [x] Windows cross-compile with MinGW GCC 15.2.0 succeeds (previously failed)
- [x] All 7 ctest tests pass