### PR TITLE
fix: improve port forwarding disable logging

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1192,16 +1192,17 @@ static void update_disable_port_forwarding(void)
 	} else {
 		int reserved = addr_is_reserved(&addr);
 		if (!disable_port_forwarding && reserved) {
+			syslog(LOG_WARNING, "Reserved / private IP address %s on ext interface %s", if_addr, ext_if_name);
 			if (GETFLAG(ALLOWPRIVATEIPV4MASK)) {
-				syslog(LOG_WARNING, "IGNORED : Reserved / private IP address %s on ext interface %s", if_addr, ext_if_name);
+				syslog(LOG_WARNING, "Allow ext interface private IPv4, ignored");
 			} else {
-				syslog(LOG_WARNING, "Reserved / private IP address %s on ext interface %s: Port forwarding is impossible", if_addr, ext_if_name);
-				syslog(LOG_INFO, "You are probably behind NAT, enable option ext_perform_stun=yes to detect public IP address");
-				syslog(LOG_INFO, "Or use ext_ip= / -o option to declare public IP address");
-				syslog(LOG_INFO, "In case that miniupnpd is thinking that it's behind symmetric NAT while it actually is full-cone");
-				syslog(LOG_INFO, "You can set option ext_allow_private_ipv4=yes to enable port forwarding");
-				syslog(LOG_INFO, "But you may still need to configure stun server or ext_ip to make it work correctly");
-				syslog(LOG_INFO, "Public IP address is required by UPnP/PCP/PMP protocols and clients do not work without it");
+				syslog(LOG_WARNING, "Port forwarding is impossible, now disabled");
+				syslog(LOG_WARNING, "You are probably behind NAT, enable option ext_perform_stun=yes to detect public IP address");
+				syslog(LOG_WARNING, "Or use ext_ip= / -o option to declare public IP address");
+				syslog(LOG_WARNING, "In case that miniupnpd is thinking that it's behind symmetric NAT while it actually is full-cone");
+				syslog(LOG_WARNING, "You can set option ext_allow_private_ipv4=yes to enable port forwarding");
+				syslog(LOG_WARNING, "But you may still need to configure stun server or ext_ip to make it work correctly");
+				syslog(LOG_WARNING, "Public IP address is required by UPnP/PCP/PMP protocols and clients do not work without it");
 				disable_port_forwarding = 1;
 			}
 		} else if (disable_port_forwarding && !reserved) {


### PR DESCRIPTION
By standardizing warning messages to the 'warning' level, we can provide users with potential solutions without having to set the default log level to 'info'.

fix: miniupnp#870