### PR TITLE
fix(miniupnpd): remove redundant assignment

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1206,7 +1206,6 @@ static void update_disable_port_forwarding(void)
 			}
 		} else if (disable_port_forwarding && !reserved) {
 			syslog(LOG_INFO, "Public IP address %s on ext interface %s: Port forwarding is enabled", if_addr, ext_if_name);
-			disable_port_forwarding = 0;
 		}
 	}
 }


### PR DESCRIPTION
The variable `disable_port_forwarding` defaults to 0, and no operations have been observed that would set its value to 1.