### PR TITLE
Sunos build fix

### DIFF
--- a/minissdpd/minissdpd.c
+++ b/minissdpd/minissdpd.c
@@ -33,6 +33,12 @@
 #include <grp.h>
 #endif
 
+#if defined(__sun)
+               /* solaris does not seem to have link_ntoa */
+               /* #define link_ntoa _link_ntoa */
+#define link_ntoa(x) "dummy-link_ntoa"
+#endif
+
 /* LOG_PERROR does not exist on Solaris */
 #ifndef LOG_PERROR
 #define LOG_PERROR 0

--- a/miniupnpd/Makefile.sunos
+++ b/miniupnpd/Makefile.sunos
@@ -26,6 +26,7 @@ CFLAGS += -fno-common
 CFLAGS += -D_XOPEN_SOURCE
 CFLAGS += -D_XOPEN_SOURCE_EXTENDED=1
 CFLAGS += -D__EXTENSIONS__
+CPPFLAGS += -I.
 CC = gcc
 RM = rm -f
 MV = mv
@@ -39,9 +40,9 @@ ARCH :sh = uname -m
 FWNAME = ipf
 
 # Solaris specific CFLAGS
-CFLAGS :sh += echo "-DSOLARIS2=`uname -r | cut -d. -f2`"
+CFLAGS += $(shell echo "-DSOLARIS2=`uname -r | cut -d. -f2`")
 # "amd64"
-CFLAGS += -m64 -mcmodel=kernel -mno-red-zone -ffreestanding
+CFLAGS += -m64
 # "sparc64"
 #CFLAGS += -m64 -mcmodel=medlow
 LDFLAGS += -m64
@@ -75,7 +76,7 @@ ALLOBJS += $(IPFOBJS)
 
 TESTUPNPDESCGENOBJS = testupnpdescgen.o upnpdescgen.o
 TESTUPNPPERMISSIONSOBJS = testupnppermissions.o upnppermissions.o
-TESTGETIFADDROBJS = testgetifaddr.o getifaddr.o
+TESTGETIFADDROBJS = testgetifaddr.o getifaddr.o getconnstatus.o
 MINIUPNPDCTLOBJS = miniupnpdctl.o
 TESTASYNCSENDTOOBJS = testasyncsendto.o asyncsendto.o upnputils.o bsd/getroute.o
 TESTPORTINUSEOBJS = testportinuse.o portinuse.o getifaddr.o upnputils.o \
@@ -197,7 +198,7 @@ config.h:	configure VERSION
 
 .SUFFIXES:	.o .c
 .c.o:
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 #	$(CC) $(CFLAGS) -c -o $(.TARGET) $(.IMPSRC)
 

--- a/miniupnpd/configure
+++ b/miniupnpd/configure
@@ -448,7 +448,7 @@ case $OS_NAME in
 		;;
 	SunOS)
 		OS_FAMILY=BSD
-		MAKEFILE=Makefile.bsd
+		MAKEFILE=Makefile.sunos
 		echo "#define USE_IFACEWATCHER 1" >> ${CONFIGFILE}
 		FW=ipf
 		echo "#define LOG_PERROR 0" >> ${CONFIGFILE}

--- a/miniupnpd/minissdp.c
+++ b/miniupnpd/minissdp.c
@@ -211,10 +211,12 @@ OpenAndConfSSDPReceiveSocket(int ipv6)
 	{
 		syslog(LOG_WARNING, "setsockopt(udp, SO_REUSEADDR): %m");
 	}
+#ifdef SO_REUSEPORT
 	if (setsockopt(s, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0)
 	{
 		syslog(LOG_WARNING, "setsockopt(udp, SO_REUSEPORT): %m");
 	}
+#endif /* SO_REUSEPORT */
 #ifdef IP_RECVIF
 	/* BSD */
 	if(!ipv6) {


### PR DESCRIPTION
There are fixes for some build-time erros under SunOS.

1. Provided a dummy for missing link_ntoa
2. Configuration provide sunos makefile as intended
3. Sunos makefile includes fixes(compilation rule was missing cppflags)

This fixes intended to build under illumos distros(SmartOS, etc.)
It is build from pkgsrc using bmake