### PR TITLE
Re-enable port forwarding properly

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1199,6 +1199,7 @@ static void update_disable_port_forwarding(void)
 			}
 		} else if (disable_port_forwarding && !reserved) {
 			syslog(LOG_INFO, "Public IP address %s on ext interface %s: Port forwarding is enabled", if_addr, ext_if_name);
+			disable_port_forwarding = 0;
 		}
 	}
 }


### PR DESCRIPTION
Before this patch the port forwarding cannot be re-enabled once it is disabled.
Revert a0ee71e9fa66b60052bb3d2cf84380b79db3f8c8.