### PR TITLE
Slim version of timeout handling

### DIFF
--- a/miniupnpc/src/connecthostport.c
+++ b/miniupnpc/src/connecthostport.c
@@ -103,9 +103,10 @@ SOCKET connecthostport(const char * host, unsigned short port,
 #endif /* #ifdef USE_GETHOSTBYNAME */
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
 #ifdef _WIN32
-	DWORD timeout;
+	DWORD timeout = MINIUPNPC_CONNECT_TIMEOUT_IN_MS; /* 3000 ms */
 #else
-	struct timeval timeout;
+	struct timeval timeout = { MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000,
+							   (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000 }; /* 3 s */
 #endif
 #endif /* #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT */
 
@@ -126,28 +127,11 @@ SOCKET connecthostport(const char * host, unsigned short port,
 	}
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
 	/* setting a 3 seconds timeout for the connect() call */
-#ifdef _WIN32
-	/* https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt
-	 * SO_RCVTIMEO DWORD Sets the timeout, in milliseconds, for blocking
-	 * receive calls. */
-	timeout = MINIUPNPC_CONNECT_TIMEOUT_IN_MS; /* milliseconds */
 	if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
-#else
-	timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-	timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
-	if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(struct timeval)) < 0)
-#endif
 	{
 		PRINT_SOCKET_ERROR("setsockopt SO_RCVTIMEO");
 	}
-#ifdef _WIN32
-	timeout = MINIUPNPC_CONNECT_TIMEOUT_IN_MS; /* milliseconds */
 	if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
-#else
-	timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-	timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
-	if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(struct timeval)) < 0)
-#endif
 	{
 		PRINT_SOCKET_ERROR("setsockopt SO_SNDTIMEO");
 	}
@@ -184,8 +168,6 @@ SOCKET connecthostport(const char * host, unsigned short port,
 		}
 		FD_SET(s, &wset);
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
-		timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-		timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
 		n = select(s + 1, NULL, &wset, NULL, &timeout);
 #else
 		n = select(s + 1, NULL, &wset, NULL, NULL);
@@ -278,25 +260,11 @@ SOCKET connecthostport(const char * host, unsigned short port,
 		}
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
 		/* setting a 3 seconds timeout for the connect() call */
-#ifdef _WIN32
-		timeout = MINIUPNPC_CONNECT_TIMEOUT_IN_MS; /* milliseconds */
 		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
-#else
-		timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-		timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
-		if(setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(struct timeval)) < 0)
-#endif
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}
-#ifdef _WIN32
-		timeout = MINIUPNPC_CONNECT_TIMEOUT_IN_MS; /* milliseconds */
 		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, (const char *)&timeout, sizeof(timeout)) < 0)
-#else
-		timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-		timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
-		if(setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(struct timeval)) < 0)
-#endif
 		{
 			PRINT_SOCKET_ERROR("setsockopt");
 		}
@@ -332,8 +300,6 @@ SOCKET connecthostport(const char * host, unsigned short port,
 			}
 			FD_SET(s, &wset);
 #ifdef MINIUPNPC_SET_SOCKET_TIMEOUT
-			timeout.tv_sec = MINIUPNPC_CONNECT_TIMEOUT_IN_MS / 1000;
-			timeout.tv_usec = (MINIUPNPC_CONNECT_TIMEOUT_IN_MS % 1000) * 1000;
 			n = select(s + 1, NULL, &wset, NULL, &timeout);
 #else
 			n = select(s + 1, NULL, &wset, NULL, NULL);


### PR DESCRIPTION
Initialisation removes multiple assignments of the same values.
Also replaced 'us' for microseconds with correct 'ms' for milliseconds, and there should be space between numbers and units.