### PR TITLE
Bump action versions and setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
        make -C minissdpd all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/i586-mingw32msvc.yml
+++ b/.github/workflows/i586-mingw32msvc.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: download packages
         run: wget -c https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-binutils_2.20-0.2ubuntu1_amd64.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32-runtime_3.15.2-0ubuntu1_all.deb https://launchpad.net/ubuntu/+archive/primary/+files/mingw32_4.2.1.dfsg-2ubuntu1_amd64.deb

--- a/.github/workflows/i686-w64-mingw32.yml
+++ b/.github/workflows/i686-w64-mingw32.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install packages
         run: sudo apt-get install gcc-mingw-w64-i686 mingw-w64-tools
@@ -29,7 +29,7 @@ jobs:
         run: make -C miniupnpc -f Makefile.mingw DLLWRAP=i686-w64-mingw32-dllwrap CC=i686-w64-mingw32-gcc WINDRES=i686-w64-mingw32-windres AR=i686-w64-mingw32-ar all dist
 
       - name: upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: miniupnpc-win32-binaries-${{github.sha}}
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: build miniupnpc with make
         run: make -C miniupnpc all check
@@ -43,7 +43,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install packages
         run: sudo apt-get install libnfnetlink-dev

--- a/.github/workflows/miniupnpc_wheels.yml
+++ b/.github/workflows/miniupnpc_wheels.yml
@@ -172,11 +172,11 @@ jobs:
       CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
 
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python.major-dot-minor }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           path: cloned
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.os.matrix == 'linux' && matrix.arch.matrix == 'arm'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Build and test
         if: matrix.os.matrix != 'windows'
@@ -238,7 +238,7 @@ jobs:
         run: |
           python -c 'import miniupnpc; print(miniupnpc)'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: wheel-${{ env.FILE_NAME }}
@@ -253,7 +253,7 @@ jobs:
 
     steps:
       - name: Download results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           pattern: wheel-*

--- a/.github/workflows/miniupnpd.yml
+++ b/.github/workflows/miniupnpd.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install packages
         run: sudo apt-get install libiptc-dev libxtables-dev libnfnetlink-dev libnftnl-dev libmnl-dev libssl-dev

--- a/.github/workflows/x86_64-w64-mingw32.yml
+++ b/.github/workflows/x86_64-w64-mingw32.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install packages
         run: sudo apt-get install gcc-mingw-w64-x86-64 mingw-w64-tools
@@ -19,7 +19,7 @@ jobs:
         run: make -C miniupnpc -f Makefile.mingw DLLWRAP=x86_64-w64-mingw32-dllwrap CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres AR=x86_64-w64-mingw32-ar all dist
 
       - name: upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: miniupnpc-win64-binaries-${{github.sha}}
           path: |


### PR DESCRIPTION
Fix deprecation
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

Add dependabot which will create PR automatically when a new version is available