### PR TITLE
miniupnpd: allow /32 CIDR masks in permission rules

### DIFF
--- a/miniupnpd/upnppermissions.c
+++ b/miniupnpd/upnppermissions.c
@@ -183,7 +183,7 @@ get_addr_or_mask(const char * s, struct in_addr * addr)
 	else if (dot_cnt == 0)
 	{
 		int n_bits = atoi(buf);
-		if (n_bits >= 32 || n_bits < 0)
+		if (n_bits > 32 || n_bits < 0)
 			return NULL;
 		addr->s_addr = !n_bits ? 0 : htonl(0xffffffffu << (32 - n_bits));
 	}


### PR DESCRIPTION
Commit 79001b1 fixed get_addr() so inet_aton() is only called for dotted IPv4 values, avoiding libc-specific handling of one-part IPv4 strings.

However, the CIDR prefix validation currently rejects n_bits >= 32, which makes /32 invalid. Since /32 is a valid IPv4 CIDR mask and was one of the cases mentioned in #895, accept 32 by changing the check to n_bits > 32.