### PR TITLE
miniupnpd: re-enable port forwarding with reserved address when ext_allow_private_ipv4 is set

### DIFF
--- a/miniupnpd/miniupnpd.c
+++ b/miniupnpd/miniupnpd.c
@@ -1205,8 +1205,10 @@ static void update_disable_port_forwarding(void)
 				syslog(LOG_INFO, "Public IP address is required by UPnP/PCP/PMP protocols and clients do not work without it");
 				disable_port_forwarding = 1;
 			}
-		} else if (disable_port_forwarding && !reserved) {
-			syslog(LOG_INFO, "Public IP address %s on ext interface %s: Port forwarding is enabled", if_addr, ext_if_name);
+		} else if (disable_port_forwarding &&
+		           (!reserved || GETFLAG(ALLOWPRIVATEIPV4MASK))) {
+			syslog(LOG_INFO, "%s IP address %s on ext interface %s: Port forwarding is enabled",
+			       reserved ? "Reserved / private" : "Public", if_addr, ext_if_name);
 			disable_port_forwarding = 0;
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #904.

On CGNAT setups running with `ext_allow_private_ipv4=yes`, once `disable_port_forwarding` is set to 1 (which happens whenever the external interface is briefly down or unconfigured, e.g. during a PPPoE reconnect), it is never cleared: the recovery condition requires a non-reserved address, but the CGNAT address is always reserved. All `AddPortMapping` / NAT-PMP / PCP requests then fail forever with 501 Action Failed, without any log message.

This extends the recovery condition so that port forwarding is also re-enabled when the address is reserved and `ext_allow_private_ipv4` is enabled. This complements #890, which restored re-enabling for the public-address case.

## Testing

Tested on an OpenWrt router (aarch64, iptables backend) behind CGNAT (external address in 100.64.0.0/10, `ext_allow_private_ipv4=yes`):

- Before the fix: after an external interface flap, `AddPortMapping` fails with 501 Action Failed forever (silent, no syslog entry), until miniupnpd is restarted
- After the fix: when the interface recovers its reserved address, port forwarding is re-enabled and `AddPortMapping` works again (verified with `upnpc` add/list/delete round-trips against the patched build)
