### PR TITLE
miniupnpd/pf: set pool address family

### DIFF
--- a/miniupnpd/pf/obsdrdr.c
+++ b/miniupnpd/pf/obsdrdr.c
@@ -448,6 +448,7 @@ int add_nat_rule(const char * ifname,
 		TAILQ_INSERT_TAIL(&pcr.rule.rpool.list, a, entries);
 
 		memcpy(&pp.addr, a, sizeof(struct pf_pooladdr));
+		pp.af = pcr.rule.af;
 		if(ioctl(dev, DIOCADDADDR, &pp) < 0)
 		{
 			syslog(LOG_ERR, "ioctl(dev, DIOCADDADDR, ...): %m");
@@ -743,6 +744,7 @@ add_redirect_rule2(const char * ifname,
 		TAILQ_INSERT_TAIL(&pcr.rule.rpool.list, a, entries);
 
 		memcpy(&pp.addr, a, sizeof(struct pf_pooladdr));
+		pp.af = pcr.rule.af;
 		if(ioctl(dev, DIOCADDADDR, &pp) < 0)
 		{
 			syslog(LOG_ERR, "ioctl(dev, DIOCADDADDR, ...): %m");


### PR DESCRIPTION
miniupnpd leaves `pfioc_pooladdr.af` unset when adding PF pool addresses with `DIOCADDADDR`.

Newer FreeBSD PF, as exposed by OPNsense 26.7, preserves and prints each pool address's own address family. With the field left zeroed, `pfctl` displays the translated address as `?` even though the mapping itself remains functional.

Set the pool address family from the parent rule in both affected paths:

* redirect rules used by TCP and UDP mappings
* the additional NAT rule used for UDP

This restores valid PF pool metadata without changing rule behavior.

Real-world reproducer: https://github.com/opnsense/plugins/issues/5635

Validation performed on macOS:

* complete PF backend build passed and linked `miniupnpd`
* relevant test executables built successfully
* `testupnppermissions.sh`, `testssdppktgen`, and `testupnpdescgen` passed
* `git diff --check` passed

FreeBSD/OPNsense runtime validation was not available locally.

Thanks!